### PR TITLE
Fix source adapters, memory usage and BLOB reader bugs

### DIFF
--- a/src/main/java/tech/ydb/importer/MetadataTask.java
+++ b/src/main/java/tech/ydb/importer/MetadataTask.java
@@ -25,6 +25,7 @@ public class MetadataTask implements Callable<MetadataTask.Out> {
     @Override
     public Out call() throws Exception {
         try (Connection con = owner.getSourceCP().getConnection()) {
+            con.setAutoCommit(true);
             TableMetadata tm = owner.getTableLister().readMetadata(con, td);
             return new Out(td, tm);
         } catch (Throwable ex) {

--- a/src/main/java/tech/ydb/importer/YdbImporter.java
+++ b/src/main/java/tech/ydb/importer/YdbImporter.java
@@ -88,6 +88,7 @@ public class YdbImporter {
         try {
             final List<TableDecision> tables = new ArrayList<>();
             try (Connection con = sourceCP.getConnection()) {
+                con.setAutoCommit(true);
                 LOG.info("Initializing the table lister...");
                 tableLister = AnyTableLister.getInstance(tableMaps, con);
                 LOG.info("Retrieving table list...");

--- a/src/main/java/tech/ydb/importer/config/SourceConfig.java
+++ b/src/main/java/tech/ydb/importer/config/SourceConfig.java
@@ -19,6 +19,7 @@ public class SourceConfig extends JdomHelper {
     private String jdbcUrl;
     private String userName;
     private String password;
+    private int fetchSize = 10000;
 
     public SourceConfig() {
     }
@@ -31,6 +32,10 @@ public class SourceConfig extends JdomHelper {
             this.jdbcUrl = getText(c, "jdbc-url");
             this.userName = getText(c, "username");
             this.password = getText(c, "password");
+            String fs = getText(c, "fetch-size", null);
+            if (fs != null) {
+                this.fetchSize = Integer.parseInt(fs.trim());
+            }
         }
     }
 
@@ -72,6 +77,14 @@ public class SourceConfig extends JdomHelper {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public int getFetchSize() {
+        return fetchSize;
+    }
+
+    public void setFetchSize(int fetchSize) {
+        this.fetchSize = fetchSize;
     }
 
 }

--- a/src/main/java/tech/ydb/importer/config/SourceConfig.java
+++ b/src/main/java/tech/ydb/importer/config/SourceConfig.java
@@ -32,9 +32,13 @@ public class SourceConfig extends JdomHelper {
             this.jdbcUrl = getText(c, "jdbc-url");
             this.userName = getText(c, "username");
             this.password = getText(c, "password");
-            String fs = getText(c, "fetch-size", null);
-            if (fs != null) {
-                this.fetchSize = Integer.parseInt(fs.trim());
+            Element fetchSizeEl = getOneChild(c, "fetch-size");
+            if (fetchSizeEl != null) {
+                int fs = getInt(fetchSizeEl);
+                if (fs < 0) {
+                    throw raiseIllegal(fetchSizeEl, null, String.valueOf(fs));
+                }
+                this.fetchSize = fs;
             }
         }
     }

--- a/src/main/java/tech/ydb/importer/config/TargetConfig.java
+++ b/src/main/java/tech/ydb/importer/config/TargetConfig.java
@@ -87,7 +87,7 @@ public class TargetConfig extends tech.ydb.importer.config.JdomHelper {
             elx = getOneChild(c, "max-blob-rows");
             if (elx != null) {
                 this.maxBlobRows = getInt(elx);
-                if (this.maxBlobRows < 0 || this.maxBlobRows > 100000) {
+                if (this.maxBlobRows < 0 || this.maxBlobRows > 1000) {
                     throw raiseIllegal(elx, null, String.valueOf(this.maxBlobRows));
                 }
             }

--- a/src/main/java/tech/ydb/importer/source/OracleTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/OracleTableLister.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import tech.ydb.importer.TableDecision;
 import tech.ydb.importer.config.TableIdentity;
 
 /**
@@ -126,6 +127,37 @@ public class OracleTableLister extends AnyTableLister {
                         String ixSchema = rs.getString(1);
                         String ixName = rs.getString(2);
                         grabIndexColumns(con, ixSchema, ixName, tm);
+                    }
+                }
+            }
+        }
+    }
+
+    /*
+     * Oracle JDBC driver reports BINARY_FLOAT and BINARY_DOUBLE as vendor-specific JDBC
+     * type codes. Ask Oracle's catalog for the authoritative type name and normalize
+     * so YdbTableBuilder picks Float/Double.
+     */
+    @Override
+    protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        super.grabColumnTypes(con, td, tm);
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT column_name, data_type FROM all_tab_columns "
+                + "WHERE owner=? AND table_name=?")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ColumnInfo ci = tm.findColumn(rs.getString(1));
+                    if (ci == null) {
+                        continue;
+                    }
+                    String dataType = rs.getString(2);
+                    if ("BINARY_FLOAT".equals(dataType)) {
+                        ci.setSqlType(java.sql.Types.REAL);
+                    } else if ("BINARY_DOUBLE".equals(dataType)) {
+                        ci.setSqlType(java.sql.Types.DOUBLE);
                     }
                 }
             }

--- a/src/main/java/tech/ydb/importer/source/PostgresTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/PostgresTableLister.java
@@ -125,24 +125,35 @@ public class PostgresTableLister extends AnyTableLister {
     @Override
     protected void grabPrimaryKey(Connection con, TableIdentity ti, TableMetadata tm)
             throws SQLException {
-        // Retrieve the primary key (if one is defined)
+        if (grabPrimaryKeyConstraint(con, ti, tm)) {
+            return;
+        }
+        chooseBestUniqueIndexAsKey(con, ti, tm);
+    }
+
+    /**
+     * Retrieve the real PRIMARY KEY definition, if it exists
+     */
+    private boolean grabPrimaryKeyConstraint(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        tm.clearKey();
         try (PreparedStatement ps = con.prepareStatement(
                 "SELECT ia.attname "
-                + "FROM pg_catalog.pg_attribute ia "
-                + "INNER JOIN pg_catalog.pg_class ic "
-                + "  ON ic.\"oid\" = ia.attrelid "
-                + "INNER JOIN pg_catalog.pg_index ix "
-                + "  ON ix.indexrelid =ic.\"oid\" "
-                + "INNER JOIN pg_catalog.pg_constraint x "
-                + "  ON x.conindid = ix.indexrelid "
-                + "INNER JOIN pg_catalog.pg_class c "
-                + "  ON c.\"oid\" = x.conrelid "
-                + "INNER JOIN pg_catalog.pg_namespace n "
-                + "  ON n.\"oid\" = c.relnamespace "
-                + "WHERE n.nspname = ? AND c.relname = ? "
-                + "  AND x.contype IN ('p', 'u') "
-                + "AND ix.indisvalid AND ix.indisunique "
-                + "ORDER BY ia.attnum")) {
+                        + "FROM pg_catalog.pg_attribute ia "
+                        + "INNER JOIN pg_catalog.pg_class ic "
+                        + "  ON ic.\"oid\" = ia.attrelid "
+                        + "INNER JOIN pg_catalog.pg_index ix "
+                        + "  ON ix.indexrelid = ic.\"oid\" "
+                        + "INNER JOIN pg_catalog.pg_constraint x "
+                        + "  ON x.conindid = ix.indexrelid "
+                        + "INNER JOIN pg_catalog.pg_class c "
+                        + "  ON c.\"oid\" = x.conrelid "
+                        + "INNER JOIN pg_catalog.pg_namespace n "
+                        + "  ON n.\"oid\" = c.relnamespace "
+                        + "WHERE n.nspname = ? AND c.relname = ? "
+                        + "  AND x.contype = 'p' "
+                        + "  AND ix.indisvalid AND ix.indisunique "
+                        + "ORDER BY ia.attnum")) {
             ps.setString(1, ti.getSchema());
             ps.setString(2, ti.getTable());
             try (ResultSet rs = ps.executeQuery()) {
@@ -151,46 +162,72 @@ public class PostgresTableLister extends AnyTableLister {
                 }
             }
         }
-        if (tm.getKey().isEmpty()) {
-            // If the key was not defined as a PK constraint, look for unique indexes.
-            // MAYBE: logic to prefer all-integer keys over varchar-based.
-            try (PreparedStatement ps = con.prepareStatement(
-                    "SELECT ix.indexrelid, COUNT(*) "
-                    + "FROM pg_catalog.pg_index ix "
-                    + "INNER JOIN pg_catalog.pg_class c "
-                    + "  ON c.\"oid\" = ix.indrelid  "
-                    + "INNER JOIN pg_catalog.pg_namespace n "
-                    + "  ON n.\"oid\" = c.relnamespace "
-                    + "WHERE n.nspname = ? AND c.relname = ? "
-                    + "  AND ix.indisvalid AND ix.indisunique "
-                    + "GROUP BY ix.indexrelid "
-                    + "ORDER BY COUNT(*), ix.indexrelid")) {
-                ps.setString(1, ti.getSchema());
-                ps.setString(2, ti.getTable());
-                try (ResultSet rs = ps.executeQuery()) {
-                    if (rs.next()) {
-                        long ixid = rs.getLong(1);
-                        if (!rs.wasNull()) {
-                            grabIndexColumns(con, ixid, tm);
-                        }
+        return !tm.getKey().isEmpty();
+    }
+
+    /**
+     * Choose the best UNIQUE index when there is no PRIMARY KEY
+     * <p>
+     * (a) Prefer an index with the smallest number of columns<br>
+     * (b) For equal-length indexes, order by index name alphabetically
+     * <p>
+     * Skip partial indexes (cover only part of the table) and
+     * expression indexes (keys are computed, not real columns)
+     */
+    private void chooseBestUniqueIndexAsKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        Long bestIndexId = null;
+        int bestKeyCount = 0;
+
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT ix.indexrelid, ix.indnkeyatts AS key_count "
+                        + "FROM pg_catalog.pg_index ix "
+                        + "INNER JOIN pg_catalog.pg_class ic "
+                        + "  ON ic.\"oid\" = ix.indexrelid "
+                        + "INNER JOIN pg_catalog.pg_class c "
+                        + "  ON c.\"oid\" = ix.indrelid "
+                        + "INNER JOIN pg_catalog.pg_namespace n "
+                        + "  ON n.\"oid\" = c.relnamespace "
+                        + "LEFT JOIN pg_catalog.pg_constraint x "
+                        + "  ON x.conindid = ix.indexrelid AND x.contype = 'p' "
+                        + "WHERE n.nspname = ? AND c.relname = ? "
+                        + "  AND ix.indisvalid AND ix.indisunique "
+                        + "  AND x.conindid IS NULL "
+                        + "  AND ix.indpred IS NULL "
+                        + "  AND ix.indexprs IS NULL "
+                        + "ORDER BY ix.indnkeyatts, ic.relname, ix.indexrelid "
+                        + "LIMIT 1")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    bestIndexId = rs.getLong(1);
+                    if (rs.wasNull()) {
+                        bestIndexId = null;
+                    } else {
+                        bestKeyCount = rs.getInt(2);
                     }
                 }
             }
         }
+
+        if (bestIndexId != null && bestKeyCount > 0) {
+            readIndexColumns(con, bestIndexId, bestKeyCount, tm);
+        }
     }
 
-    private void grabIndexColumns(Connection con, long ixid, TableMetadata tm)
+    private void readIndexColumns(Connection con, long indexRelId, int keyCount, TableMetadata tm)
             throws SQLException {
         try (PreparedStatement ps = con.prepareStatement(
                 "SELECT ia.attname "
                 + "FROM pg_catalog.pg_attribute ia "
-                + "INNER JOIN pg_catalog.pg_class ic "
-                + "  ON ic.\"oid\" = ia.attrelid "
-                + "INNER JOIN pg_catalog.pg_index ix "
-                + "  ON ix.indexrelid =ic.\"oid\" "
-                + "WHERE ix.indexrelid = ? "
+                + "WHERE ia.attrelid = ? "
+                + "  AND ia.attnum > 0 "
+                + "  AND NOT ia.attisdropped "
+                + "  AND ia.attnum <= ? "
                 + "ORDER BY ia.attnum")) {
-            ps.setLong(1, ixid);
+            ps.setLong(1, indexRelId);
+            ps.setInt(2, keyCount);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     tm.addKey(rs.getString(1));

--- a/src/main/java/tech/ydb/importer/source/PostgresTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/PostgresTableLister.java
@@ -258,7 +258,7 @@ public class PostgresTableLister extends AnyTableLister {
                 + "  AND a.atttypid = t.oid "
                 + "  AND c.relnamespace = s.oid"
                 + "  AND t.typname in ('oid', 'lo') "
-                + "  AND c.relkind='r' "
+                + "  AND c.relkind IN ('r', 'p') "
                 + "  AND s.nspname=? AND c.relname=?";
         try (PreparedStatement ps = con.prepareStatement(sqlBlob)) {
             ps.setString(1, td.getSchema());

--- a/src/main/java/tech/ydb/importer/target/BlobReader.java
+++ b/src/main/java/tech/ydb/importer/target/BlobReader.java
@@ -2,6 +2,7 @@ package tech.ydb.importer.target;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.sql.Blob;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +90,8 @@ public class BlobReader extends ValueReader {
 
     private InputStream openStream(ResultSet rs, int index) throws Exception {
         if (isBlob) {
-            return rs.getBlob(index).getBinaryStream();
+            Blob blob = rs.getBlob(index);
+            return blob == null ? null : blob.getBinaryStream();
         }
         return rs.getBinaryStream(index);
     }

--- a/src/main/java/tech/ydb/importer/target/BlobReader.java
+++ b/src/main/java/tech/ydb/importer/target/BlobReader.java
@@ -54,11 +54,6 @@ public class BlobReader extends ValueReader {
                 ctx, tablePath, "blob rows upsert issue for " + tablePath, progress::countBlobRows
         );
 
-        if (maxBlobRecords < 1) {
-            maxBlobRecords = 1;
-        } else if (maxBlobRecords > 1000) {
-            maxBlobRecords = 1000;
-        }
         this.maxBlobRecords = maxBlobRecords;
         this.posId = BLOB_ROW.getMemberIndex("id");
         this.posPos = BLOB_ROW.getMemberIndex("pos");

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -39,6 +39,7 @@ public class LoadDataTask implements Callable<Boolean> {
     private final ProgressCounter progress;
 
     private final int maxBatchRows;
+    private final int fetchSize;
 
     public LoadDataTask(YdbImporter owner, ProgressCounter progress, TableDecision tab) {
         this.source = owner.getSourceCP();
@@ -53,6 +54,7 @@ public class LoadDataTask implements Callable<Boolean> {
         this.tab = tab;
         this.progress = progress;
         this.maxBatchRows = owner.getConfig().getTarget().getMaxBatchRows();
+        this.fetchSize = owner.getConfig().getSource().getFetchSize();
     }
 
     @Override
@@ -68,6 +70,7 @@ public class LoadDataTask implements Callable<Boolean> {
         LOG.info("Loading data from source table {}.{}", tab.getSchema(), tab.getTable());
         try (Connection con = source.getConnection()) {
             try (PreparedStatement ps = con.prepareStatement(tab.getMetadata().getBasicSql())) {
+                ps.setFetchSize(fetchSize);
                 try (ResultSet rs = ps.executeQuery()) {
                     long copied = copyData(rs);
                     LOG.info("Copied {} rows from source table {}.{}", copied, tab.getSchema(), tab.getTable());

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -69,14 +69,18 @@ public class LoadDataTask implements Callable<Boolean> {
         }
         LOG.info("Loading data from source table {}.{}", tab.getSchema(), tab.getTable());
         try (Connection con = source.getConnection()) {
+            long copied;
             try (PreparedStatement ps = con.prepareStatement(tab.getMetadata().getBasicSql())) {
                 ps.setFetchSize(fetchSize);
                 try (ResultSet rs = ps.executeQuery()) {
-                    long copied = copyData(rs);
-                    LOG.info("Copied {} rows from source table {}.{}", copied, tab.getSchema(), tab.getTable());
-                    return true;
+                    copied = copyData(rs);
                 }
             }
+            if (!con.getAutoCommit()) {
+                con.commit();
+            }
+            LOG.info("Copied {} rows from source table {}.{}", copied, tab.getSchema(), tab.getTable());
+            return true;
         } catch (Throwable e) {
             LOG.error("Failed to load data from table {}.{}", tab.getSchema(), tab.getTable(), e);
             tab.setFailure(true);

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -39,6 +39,7 @@ public class LoadDataTask implements Callable<Boolean> {
     private final ProgressCounter progress;
 
     private final int maxBatchRows;
+    private final int maxBlobRows;
     private final int fetchSize;
 
     public LoadDataTask(YdbImporter owner, ProgressCounter progress, TableDecision tab) {
@@ -54,6 +55,7 @@ public class LoadDataTask implements Callable<Boolean> {
         this.tab = tab;
         this.progress = progress;
         this.maxBatchRows = owner.getConfig().getTarget().getMaxBatchRows();
+        this.maxBlobRows = owner.getConfig().getTarget().getMaxBlobRows();
         this.fetchSize = owner.getConfig().getSource().getFetchSize();
     }
 
@@ -167,7 +169,7 @@ public class LoadDataTask implements Callable<Boolean> {
                 } else {
                     String blobPath = target.getDatabase() + "/" + tt.getFullName();
                     boolean isBlob = ci.isBlobAsObject();
-                    ValueReader reader = new BlobReader(blobPath, target.getRetryCtx(), progress, maxBatchRows, isBlob);
+                    ValueReader reader = new BlobReader(blobPath, target.getRetryCtx(), progress, maxBlobRows, isBlob);
                     index[i] = new ColumnIndex(ixTarget, reader);
                 }
             } else {

--- a/src/main/java/tech/ydb/importer/target/SynthKey.java
+++ b/src/main/java/tech/ydb/importer/target/SynthKey.java
@@ -28,6 +28,7 @@ public class SynthKey {
     }
 
     public void update(ByteBuffer buffer) {
+        buffer.flip();
         digest.update(buffer);
     }
 

--- a/src/main/java/tech/ydb/importer/target/YdbTableBuilder.java
+++ b/src/main/java/tech/ydb/importer/target/YdbTableBuilder.java
@@ -276,7 +276,7 @@ public class YdbTableBuilder {
     private void addSyntheticKey(StringBuilder sb, Map<String, Type> types) {
         String field = TargetTable.SYNTH_KEY_FIELD;
         types.put(field, PrimitiveType.Text);
-        sb.append("  ").append(field).append(" Text,").append(EOL)
+        sb.append("  ").append(field).append(" Text NOT NULL,").append(EOL)
                 .append("  PRIMARY KEY (").append(field).append(")").append(EOL);
     }
 

--- a/src/main/java/tech/ydb/importer/target/YdbTableBuilder.java
+++ b/src/main/java/tech/ydb/importer/target/YdbTableBuilder.java
@@ -206,6 +206,7 @@ public class YdbTableBuilder {
             case java.sql.Types.DOUBLE:
                 return PrimitiveType.Double;
             case java.sql.Types.FLOAT:
+            case java.sql.Types.REAL:
                 return PrimitiveType.Float;
             case java.sql.Types.VARCHAR:
             case java.sql.Types.CHAR:


### PR DESCRIPTION
## Synthetic key

Исправлен баг в генерации `SynthKey` для `IntReader` и `LongReader`. Позиция в буфере не сбрасывалась после put значения, из-за чего все строки с одинаковыми строковыми/байтовыми полями, но разными числовыми, получали одинаковый `SynthKey`.

Колонка синтетического первичного ключа в создаваемой YDB таблице теперь помечается NOT NULL.

## PostgreSQL

Исправлен выбор первичного ключа. Ранее Postgres объединял колонки PK и всех UNIQUE ограничений в один составной ключ для вставки в YDB. После исправления выбор ключа соответствует логике:
- если в источнике есть PK, используется он
- иначе берётся UNIQUE индекс с минимальным числом колонок, при равном числе колонок выбор детерминирован по имени индекса
- partial индексы и expression индексы из кандидатов исключаются

Исправлено обнаружение BLOB колонок для таблиц с партициями. Запрос в `grabColumnTypes` использовал фильтр `c.relkind='r'`, который пропускал partitioned parent (у них `relkind='p'`) и OID/LO колонки определялись как обычные числовые.

## Oracle

Исправлено отображение колонок `BINARY_FLOAT` и `BINARY_DOUBLE`. JDBC драйвер Oracle возвращает для них vendor specific JDBC коды, а не стандартные `Types.REAL` и `Types.DOUBLE`, из-за чего `YdbTableBuilder` не мог сопоставить тип. Теперь `OracleTableLister` дополнительно запрашивает `ALL_TAB_COLUMNS` и переводит `BINARY_FLOAT` в `Types.REAL`, `BINARY_DOUBLE` в `Types.DOUBLE`.

## Memory and streaming

Добавлен настраиваемый `fetchSize` в `SourceConfig`, который применяется к `PreparedStatement` при чтении данных. Без него JDBC драйверы буферизуют весь ResultSet в клиенте и получается OOM на больших таблицах. Тест на PostgreSQL: без курсора 10M строк потребляли около 4.5 GB, с курсором около 190 MB.

В `MetadataTask` и `YdbImporter` выставляется `setAutoCommit(true)` на соединении, а в `LoadDataTask` после чтения данных вызывается `con.commit()`, чтобы транзакция на источнике закрывалась корректно.

## BLOB handling

`BlobReader` теперь получает `maxBlobRows` вместо `maxBatchRows`. Поле `maxBlobRows` уже существовало в `TargetConfig`, но не пробрасывалось в ридеры, из-за чего размер блока для BLOB совпадал с размером батча основной таблицы.

Добавлена обработка NULL значений в BLOB колонках, раньше `BlobReader` на них падал.