### PR TITLE
Feature/new sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,125 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  MAVEN_ARGS: --batch-mode -ntp -Dstyle.color=always
+  JDK_JAVA_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED
+
+permissions:
+  contents: read
+
+jobs:
+  checkstyle:
+    name: Checkstyle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run checkstyle
+        run: mvn $MAVEN_ARGS checkstyle:check
+
+  unit-tests:
+    name: Unit tests
+    needs: checkstyle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run unit tests
+        run: mvn $MAVEN_ARGS test -Dtest='ImporterConfigTest' -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false
+
+      - name: Check benchmark compiles
+        run: mvn $MAVEN_ARGS -P benchmark test-compile
+
+  compatibility:
+    name: Compatibility (JDK ${{ matrix.java }})
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['8', '11', '17', '21', '25']
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run integration tests (postgres)
+        run: mvn $MAVEN_ARGS test -Dtest='PostgresYdbImporterTest,AllDbVerificationTest' -Dverify.only=postgres -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false
+
+  integration-tests:
+    name: Integration (${{ matrix.db }})
+    needs: compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - db: MySQL
+            test: 'MySqlYdbImporterTest,AllDbVerificationTest'
+            verifyOnly: mysql
+            timeout: 10
+          - db: MariaDB
+            test: 'MariaDbYdbImporterTest,AllDbVerificationTest'
+            verifyOnly: mariadb
+            timeout: 10
+          - db: MariaDB ColumnStore
+            test: 'MariaDbColumnStoreYdbImporterTest'
+            timeout: 10
+          - db: ClickHouse
+            test: 'ClickHouseYdbImporterTest,AllDbVerificationTest'
+            verifyOnly: clickhouse
+            timeout: 10
+          - db: Greenplum
+            test: 'GreenplumYdbImporterTest,AllDbVerificationTest'
+            verifyOnly: greenplum
+            timeout: 10
+          - db: Oracle
+            test: 'OracleYdbImporterTest,AllDbVerificationTest'
+            verifyOnly: oracle
+            timeout: 20
+          - db: Db2
+            test: 'Db2YdbImporterTest,AllDbVerificationTest'
+            verifyOnly: db2
+            timeout: 20
+          - db: SAP HANA
+            test: 'HanaYdbImporterTest,AllDbVerificationTest'
+            verifyOnly: hana
+            timeout: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run integration tests (${{ matrix.db }})
+        run: mvn $MAVEN_ARGS test -Dtest='${{ matrix.test }}' ${{ matrix.verifyOnly && format('-Dverify.only={0}', matrix.verifyOnly) || '' }} -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,29 @@ jobs:
       - name: Run checkstyle
         run: mvn $MAVEN_ARGS checkstyle:check
 
+  build:
+    name: Build
+    needs: checkstyle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Check benchmark compiles
+        run: mvn $MAVEN_ARGS -P benchmark test-compile
+
+      - name: Build distribution
+        run: mvn $MAVEN_ARGS package -Dmaven.test.skip=true -Dcheckstyle.skip=true
+
   unit-tests:
     name: Unit tests
-    needs: checkstyle
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -46,9 +66,6 @@ jobs:
 
       - name: Run unit tests
         run: mvn $MAVEN_ARGS test -Dtest='ImporterConfigTest' -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false
-
-      - name: Check benchmark compiles
-        run: mvn $MAVEN_ARGS -P benchmark test-compile
 
   compatibility:
     name: Compatibility (JDK ${{ matrix.java }})

--- a/README-ru.md
+++ b/README-ru.md
@@ -6,10 +6,15 @@
 
 * [PostgreSQL](https://www.postgresql.org/),
 * [MySQL](https://www.mysql.com/),
+* [MariaDB](https://mariadb.org/) (включая [ColumnStore](https://mariadb.com/docs/analytics/mariadb-columnstore)),
 * [Oracle Database](https://www.oracle.com/database/),
 * [Microsoft SQL Server](https://www.microsoft.com/sql-server/),
 * [IBM Db2](https://www.ibm.com/products/db2),
-* [IBM Informix](https://www.ibm.com/products/informix).
+* [IBM Informix](https://www.ibm.com/products/informix),
+* [ClickHouse](https://clickhouse.com/),
+* [SAP HANA](https://www.sap.com/products/data-cloud/hana.html),
+* [Vertica](https://www.opentext.com/products/analytics-database),
+* [Greenplum](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-greenplum/7.html).
 
 Непротестированные источники данных JDBC с определенной вероятностью также могут оказаться поддержаны утилитой, поскольку в ней используются стандартные API для доступа к данным и метаданным.
 
@@ -127,10 +132,15 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
 Примеры файлов настроек с комментариями:
 * [для PostgreSQL](scripts/sample-postgres.xml);
 * [для MySQL](scripts/sample-mysql.xml);
+* [для MariaDB](scripts/sample-mariadb.xml);
 * [для Oracle Database](scripts/sample-oracle.xml);
 * [для Microsoft SQL Server](scripts/sample-mssql.xml);
 * [для IBM Db2](scripts/sample-db2.xml);
-* [для IBM Informix](scripts/sample-informix.xml).
+* [для IBM Informix](scripts/sample-informix.xml);
+* [для ClickHouse](scripts/sample-clickhouse.xml);
+* [для SAP HANA](scripts/sample-hana.xml);
+* [для Vertica](scripts/sample-vertica.xml);
+* [для Greenplum](scripts/sample-greenplum.xml).
 
 Описание формата файла настроек:
 
@@ -159,7 +169,7 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
     <!-- Параметры подключения к БД-источнику.
          type - обязательный атрибут, влияющий на логику взаимодействия с источником
       -->
-    <source type="generic|postgresql|mysql|oracle|mssql|db2|informix">
+    <source type="generic|postgresql|greenplum|mysql|mariadb|oracle|mssql|db2|informix|clickhouse|hana|vertica">
         <!-- Имя основного класса драйвера JDBC. Типичные значения:
               org.postgresql.Driver
               com.mysql.cj.jdbc.Driver
@@ -168,6 +178,10 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
               com.microsoft.sqlserver.jdbc.SQLServerDriver
               com.ibm.db2.jcc.DB2Driver
               com.informix.jdbc.IfxDriver
+              com.clickhouse.jdbc.ClickHouseDriver
+              com.sap.db.jdbc.Driver
+              com.vertica.jdbc.Driver
+              (для greenplum используется драйвер PostgreSQL: org.postgresql.Driver)
         -->
         <jdbc-class>driver-class-name</jdbc-class>
         <!-- URL JDBC для подключения к источнику. Примеры значений:
@@ -178,6 +192,10 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
               jdbc:sqlserver://localhost;encrypt=true;trustServerCertificate=true;database=AdventureWorks2022;
               jdbc:db2://localhost:50000/SAMPLE
               jdbc:informix-sqli://localhost:9088/stores_demo:INFORMIXSERVER=informix
+              jdbc:clickhouse://hostname:8123/default
+              jdbc:sap://hostname:39041
+              jdbc:vertica://hostname:5433/VMart
+              (для greenplum используется URL PostgreSQL: jdbc:postgresql://hostname:5432/dbname)
         -->
         <jdbc-url>jdbc-url</jdbc-url>
         <username>username</username>

--- a/README-ru.md
+++ b/README-ru.md
@@ -274,7 +274,7 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
              N    - целое >= 2, разбить диапазон первой колонки ключа на N равных
                     интервалов (по ydb-partition-from/to, иначе MIN/MAX источника).
              none - не задавать, YDB управляет партициями сам.
-             По умолчанию auto. Можно переопределить в <table-ref>. -->
+             По умолчанию none. Можно переопределить в <table-ref>. -->
         <ydb-partition-count>auto</ydb-partition-count>
     </table-options>
     <!-- Фильтр для отбора копируемых таблиц с источника -->

--- a/README-ru.md
+++ b/README-ru.md
@@ -163,6 +163,8 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
         <buffer-count>4</buffer-count>
         <!-- Использовать ли колоночный формат Apache Arrow при записи в YDB.
              Увеличивает скорость загрузки. Требует YDB версии 26.1 или более поздней.
+             На Java 16 и новее запускать с
+             JDK_JAVA_OPTIONS=--add-opens=java.base/java.nio=ALL-UNNAMED
          -->
         <use-arrow>false</use-arrow>
     </workers>

--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ Right now the tested data sources include the following:
 
 * [PostgreSQL](https://www.postgresql.org/),
 * [MySQL](https://www.mysql.com/),
+* [MariaDB](https://mariadb.org/) (including [ColumnStore](https://mariadb.com/docs/analytics/mariadb-columnstore)),
 * [Oracle Database](https://www.oracle.com/database/),
 * [Microsoft SQL Server](https://www.microsoft.com/sql-server/),
 * [IBM Db2](https://www.ibm.com/products/db2),
-* [IBM Informix](https://www.ibm.com/products/informix).
+* [IBM Informix](https://www.ibm.com/products/informix),
+* [ClickHouse](https://clickhouse.com/),
+* [SAP HANA](https://www.sap.com/products/data-cloud/hana.html),
+* [Vertica](https://www.opentext.com/products/analytics-database),
+* [Greenplum](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-greenplum/7.html).
 
 Other data sources will probably work, too, as the tool uses the generic JDBC APIs to retrieve data and metadata.
 
@@ -127,10 +132,15 @@ Reading and target partitioning are resolved independently.
 Sample configuration files:
 * [for PostgreSQL](scripts/sample-postgres.xml);
 * [for MySQL](scripts/sample-mysql.xml);
+* [for MariaDB](scripts/sample-mariadb.xml);
 * [for Oracle Database](scripts/sample-oracle.xml);
 * [for Microsoft SQL Server](scripts/sample-mssql.xml);
 * [for IBM Db2](scripts/sample-db2.xml);
-* [for IBM Informix](scripts/sample-informix.xml).
+* [for IBM Informix](scripts/sample-informix.xml);
+* [for ClickHouse](scripts/sample-clickhouse.xml);
+* [for SAP HANA](scripts/sample-hana.xml);
+* [for Vertica](scripts/sample-vertica.xml);
+* [for Greenplum](scripts/sample-greenplum.xml).
 
 Below is the definition of the configuration file structure:
 
@@ -159,7 +169,7 @@ Below is the definition of the configuration file structure:
     <!-- Source database connection parameters.
          type - the required attribute defining the type of the data source
       -->
-    <source type="generic|postgresql|mysql|oracle|mssql|db2|informix">
+    <source type="generic|postgresql|greenplum|mysql|mariadb|oracle|mssql|db2|informix|clickhouse|hana|vertica">
         <!-- JDBC driver class name to be used. Typical values:
               org.postgresql.Driver
               com.mysql.cj.jdbc.Driver
@@ -168,6 +178,10 @@ Below is the definition of the configuration file structure:
               com.microsoft.sqlserver.jdbc.SQLServerDriver
               com.ibm.db2.jcc.DB2Driver
               com.informix.jdbc.IfxDriver
+              com.clickhouse.jdbc.ClickHouseDriver
+              com.sap.db.jdbc.Driver
+              com.vertica.jdbc.Driver
+              (for greenplum, same as PostgreSQL: org.postgresql.Driver)
         -->
         <jdbc-class>driver-class-name</jdbc-class>
         <!-- JDBC driver URL. Value templates:
@@ -178,6 +192,10 @@ Below is the definition of the configuration file structure:
               jdbc:sqlserver://localhost;encrypt=true;trustServerCertificate=true;database=AdventureWorks2022;
               jdbc:db2://localhost:50000/SAMPLE
               jdbc:informix-sqli://localhost:9088/stores_demo:INFORMIXSERVER=informix
+              jdbc:clickhouse://hostname:8123/default
+              jdbc:sap://hostname:39041
+              jdbc:vertica://hostname:5433/VMart
+              (for greenplum, same as PostgreSQL: jdbc:postgresql://hostname:5432/dbname)
         -->
         <jdbc-url>jdbc-url</jdbc-url>
         <username>username</username>

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Below is the definition of the configuration file structure:
         <buffer-count>4</buffer-count>
         <!-- Use Apache Arrow columnar format for writes to YDB.
              Increases load speed. Requires YDB version 26.1 or later.
+             On Java 16 or newer, run with
+             JDK_JAVA_OPTIONS=--add-opens=java.base/java.nio=ALL-UNNAMED
          -->
         <use-arrow>false</use-arrow>
     </workers>

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Below is the definition of the configuration file structure:
              N    - integer >= 2, split the first key column range into N equal
                     intervals (from ydb-partition-from/to, otherwise source MIN/MAX).
              none - do not set it, YDB manages partitions on its own.
-             Default is auto. Can be overridden in <table-ref>. -->
+             Default is none. Can be overridden in <table-ref>. -->
         <ydb-partition-count>auto</ydb-partition-count>
     </table-options>
     <!-- Table map filters the source tables and defines the conversion modes for them. -->

--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,47 @@
                     <artifactId>ojdbc8</artifactId>
                     <version>23.7.0.25.01</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>testcontainers-clickhouse</artifactId>
+                    <version>2.0.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>testcontainers-mariadb</artifactId>
+                    <version>2.0.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>testcontainers-db2</artifactId>
+                    <version>2.0.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.clickhouse</groupId>
+                    <artifactId>clickhouse-jdbc</artifactId>
+                    <version>0.9.8</version>
+                    <classifier>all</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>org.mariadb.jdbc</groupId>
+                    <artifactId>mariadb-java-client</artifactId>
+                    <version>3.5.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.vertica.jdbc</groupId>
+                    <artifactId>vertica-jdbc</artifactId>
+                    <version>24.1.0-0</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sap.cloud.db.jdbc</groupId>
+                    <artifactId>ngdbc</artifactId>
+                    <version>2.28.6</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.ibm.db2</groupId>
+                    <artifactId>jcc</artifactId>
+                    <version>12.1.4.0</version>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,18 @@
             <version>2.28.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-db2</artifactId>
+            <version>2.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.db2</groupId>
+            <artifactId>jcc</artifactId>
+            <version>12.1.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,13 @@
             <version>4.50.10.1</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-jdbc</artifactId>
+            <version>0.9.8</version>
+            <classifier>all</classifier>
+            <scope>runtime</scope>
+        </dependency>
         -->
         <dependency>
             <groupId>tech.ydb.test</groupId>
@@ -170,6 +177,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-clickhouse</artifactId>
+            <version>2.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.7</version>
@@ -185,6 +198,13 @@
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <version>23.7.0.25.01</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-jdbc</artifactId>
+            <version>0.9.8</version>
+            <classifier>all</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,12 @@
             <version>24.1.0-0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.sap.cloud.db.jdbc</groupId>
+            <artifactId>ngdbc</artifactId>
+            <version>2.28.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>3.5.4</version>
                         <configuration>
-                            <argLine>@{argLine} --add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+                            <argLine>@{argLine}</argLine>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -433,7 +433,7 @@
                         <version>3.5.0</version>
                         <configuration>
                             <executable>java</executable>
-                            <commandlineArgs>--add-opens=java.base/java.nio=ALL-UNNAMED -classpath %classpath ${bench.mainClass} ${exec.args}</commandlineArgs>
+                            <commandlineArgs>-classpath %classpath ${bench.mainClass} ${exec.args}</commandlineArgs>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.5.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>12.6.0.jre8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,12 @@
             <version>3.5.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vertica.jdbc</groupId>
+            <artifactId>vertica-jdbc</artifactId>
+            <version>24.1.0-0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.vertica.jdbc</groupId>
+            <artifactId>vertica-jdbc</artifactId>
+            <version>24.1.0-0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>12.6.0.jre8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -405,29 +405,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>io.github.git-commit-id</groupId>
-                        <artifactId>git-commit-id-maven-plugin</artifactId>
-                        <version>9.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>get-git-info</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-                            <includeOnlyProperties>
-                                <includeOnlyProperty>git.commit.id.abbrev</includeOnlyProperty>
-                                <includeOnlyProperty>git.commit.id.full</includeOnlyProperty>
-                                <includeOnlyProperty>git.dirty</includeOnlyProperty>
-                            </includeOnlyProperties>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <version>3.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.6</version>
             <classifier>all</classifier>
             <scope>runtime</scope>
         </dependency>
@@ -227,7 +227,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.6</version>
             <classifier>all</classifier>
             <scope>test</scope>
         </dependency>
@@ -515,7 +515,7 @@
                 <dependency>
                     <groupId>com.clickhouse</groupId>
                     <artifactId>clickhouse-jdbc</artifactId>
-                    <version>0.9.8</version>
+                    <version>0.9.6</version>
                     <classifier>all</classifier>
                 </dependency>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mariadb</artifactId>
+            <version>2.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.7</version>
@@ -211,6 +217,12 @@
             <artifactId>clickhouse-jdbc</artifactId>
             <version>0.9.8</version>
             <classifier>all</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.5.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>com.ibm.db2</groupId>
             <artifactId>jcc</artifactId>
-            <version>11.5.9.0</version>
+            <version>12.1.4.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.sap.cloud.db.jdbc</groupId>
+            <artifactId>ngdbc</artifactId>
+            <version>2.28.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>12.6.0.jre8</version>

--- a/scripts/sample-clickhouse.xml
+++ b/scripts/sample-clickhouse.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ClickHouse to YDB importer job configuration example -->
+<ydb-importer>
+    <workers>
+        <reader-pool size="4"/>
+    </workers>
+    <source type="clickhouse">
+        <jdbc-class>com.clickhouse.jdbc.ClickHouseDriver</jdbc-class>
+        <jdbc-url>jdbc:clickhouse://hostname:8123/default</jdbc-url>
+        <username>default</username>
+        <password>password</password>
+        <!-- ClickHouse has no JDBC cursor, so this sets rows per partition read chunk
+             (recommended 200000 or higher) -->
+        <fetch-size>200000</fetch-size>
+    </source>
+    <target type="ydb">
+        <script-file>sample-clickhouse.yql.tmp</script-file>
+        <connection-string>grpcs://ydb.serverless.yandexcloud.net:2135?database=/ru-central1/b1gfvslmokutuvt2g019/etn63999hrinbapmef6g</connection-string>
+        <!--
+        <connection-string>grpcs://hostname.demo.com:2135?database=/local</connection-string>
+        -->
+        <!-- Custom TLS certificate file, if needed
+        <tls-certificate-file>ca.crt</tls-certificate-file>
+        -->
+        <!-- ENV, NONE, STATIC, METADATA, SAKEY -->
+        <auth-mode>ENV</auth-mode>
+        <!-- auth-mode: STATIC
+        <static-login>username</static-login>
+        <static-password>password</static-password>
+        -->
+        <!-- auth-mode: SAKEY
+        <sa-key-file>ydb-sa-keyfile.json</sa-key-file>
+        -->
+        <replace-existing>true</replace-existing>
+        <load-data>true</load-data>
+        <max-batch-rows>1000</max-batch-rows>
+        <max-blob-rows>200</max-blob-rows>
+    </target>
+    <table-options name="default">
+        <!--  ASIS, LOWER, UPPER -->
+        <case-mode>ASIS</case-mode>
+        <!-- Substitution values: ${schema}, ${table} -->
+        <table-name-format>chimp1/${schema}/${table}</table-name-format>
+        <!-- Substitution values: ${schema}, ${table}, ${field} -->
+        <blob-name-format>chimp1/${schema}/${table}_${field}</blob-name-format>
+        <!-- DATE_NEW, DATE, INT, STR -->
+        <conv-date>DATE_NEW</conv-date>
+        <conv-timestamp>DATE_NEW</conv-timestamp>
+        <allow-custom-decimal>true</allow-custom-decimal>
+        <skip-unknown-types>true</skip-unknown-types>
+    </table-options>
+    <table-map options="default">
+        <include-schemas regexp="true">.*</include-schemas>
+        <!-- Possible extra tags: include-tables, exclude-tables, exclude-schemas -->
+    </table-map>
+    <table-ref options="default">
+        <schema-name>system</schema-name>
+        <table-name>tables</table-name>
+        <key-column>database</key-column>
+        <key-column>name</key-column>
+    </table-ref>
+    <table-ref options="default">
+        <schema-name>system</schema-name>
+        <table-name>columns</table-name>
+        <query-text>SELECT database, table, name, type FROM system.columns</query-text>
+        <key-column>database</key-column>
+        <key-column>table</key-column>
+        <key-column>name</key-column>
+    </table-ref>
+</ydb-importer>

--- a/scripts/sample-db2.xml
+++ b/scripts/sample-db2.xml
@@ -6,18 +6,21 @@
     </workers>
     <source type="db2">
         <jdbc-class>com.ibm.db2.jcc.DB2Driver</jdbc-class>
-        <jdbc-url>jdbc:db2://localhost:50000/SAMPLE</jdbc-url>
+        <jdbc-url>jdbc:db2://hostname:50000/SAMPLE</jdbc-url>
         <username>db2inst1</username>
         <password>password</password>
     </source>
     <target type="ydb">
         <script-file>sample-db2.yql.tmp</script-file>
-        <connection-string>grpc://localhost:2136?database=/Root/test</connection-string>
+        <connection-string>grpcs://ydb.serverless.yandexcloud.net:2135?database=/ru-central1/b1gfvslmokutuvt2g019/etn63999hrinbapmef6g</connection-string>
+        <!--
+        <connection-string>grpcs://hostname.demo.com:2135?database=/local</connection-string>
+        -->
         <!-- Custom TLS certificate file, if needed
         <tls-certificate-file>ca.crt</tls-certificate-file>
         -->
         <!-- ENV, NONE, STATIC, METADATA, SAKEY -->
-        <auth-mode>NONE</auth-mode>
+        <auth-mode>ENV</auth-mode>
         <!-- auth-mode: STATIC
         <static-login>username</static-login>
         <static-password>password</static-password>
@@ -45,7 +48,20 @@
     </table-options>
     <table-map options="default">
         <include-schemas regexp="true">.*</include-schemas>
-        <exclude-schemas>INFORMATION_SCHEMA</exclude-schemas>
         <!-- Possible extra tags: include-tables, exclude-tables, exclude-schemas -->
     </table-map>
+    <table-ref options="default">
+        <schema-name>SYSCAT</schema-name>
+        <table-name>TABLES</table-name>
+        <key-column>TABSCHEMA</key-column>
+        <key-column>TABNAME</key-column>
+    </table-ref>
+    <table-ref options="default">
+        <schema-name>SYSCAT</schema-name>
+        <table-name>COLUMNS</table-name>
+        <query-text>SELECT * FROM SYSCAT.COLUMNS</query-text>
+        <key-column>TABSCHEMA</key-column>
+        <key-column>TABNAME</key-column>
+        <key-column>COLNAME</key-column>
+    </table-ref>
 </ydb-importer>

--- a/scripts/sample-greenplum.xml
+++ b/scripts/sample-greenplum.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Greenplum to YDB importer job configuration example.
+     Greenplum is PostgreSQL-compatible, the standard PostgreSQL JDBC driver is used. -->
+<ydb-importer>
+    <workers>
+        <reader-pool size="4"/>
+    </workers>
+    <source type="greenplum">
+        <jdbc-class>org.postgresql.Driver</jdbc-class>
+        <jdbc-url>jdbc:postgresql://hostname:5432/dbname</jdbc-url>
+        <username>gpadmin</username>
+        <password>password</password>
+    </source>
+    <target type="ydb">
+        <script-file>sample-greenplum.yql.tmp</script-file>
+        <connection-string>grpcs://ydb.serverless.yandexcloud.net:2135?database=/ru-central1/b1gfvslmokutuvt2g019/etn63999hrinbapmef6g</connection-string>
+        <!--
+        <connection-string>grpcs://hostname.demo.com:2135?database=/local</connection-string>
+        -->
+        <!-- Custom TLS certificate file, if needed
+        <tls-certificate-file>ca.crt</tls-certificate-file>
+        -->
+        <!-- ENV, NONE, STATIC, METADATA, SAKEY -->
+        <auth-mode>ENV</auth-mode>
+        <!-- auth-mode: STATIC
+        <static-login>username</static-login>
+        <static-password>password</static-password>
+        -->
+        <!-- auth-mode: SAKEY
+        <sa-key-file>ydb-sa-keyfile.json</sa-key-file>
+        -->
+        <replace-existing>true</replace-existing>
+        <load-data>true</load-data>
+        <max-batch-rows>1000</max-batch-rows>
+        <max-blob-rows>200</max-blob-rows>
+    </target>
+    <table-options name="default">
+        <!--  ASIS, LOWER, UPPER -->
+        <case-mode>ASIS</case-mode>
+        <!-- Substitution values: ${schema}, ${table} -->
+        <table-name-format>gpimp1/${schema}/${table}</table-name-format>
+        <!-- Substitution values: ${schema}, ${table}, ${field} -->
+        <blob-name-format>gpimp1/${schema}/${table}_${field}</blob-name-format>
+        <!-- DATE_NEW, DATE, INT, STR -->
+        <conv-date>DATE_NEW</conv-date>
+        <conv-timestamp>DATE_NEW</conv-timestamp>
+        <allow-custom-decimal>true</allow-custom-decimal>
+        <skip-unknown-types>true</skip-unknown-types>
+    </table-options>
+    <table-map options="default">
+        <include-schemas regexp="true">.*</include-schemas>
+        <!-- Possible extra tags: include-tables, exclude-tables, exclude-schemas -->
+    </table-map>
+    <table-ref options="default">
+        <schema-name>information_schema</schema-name>
+        <table-name>columns</table-name>
+        <key-column>table_schema</key-column>
+        <key-column>table_name</key-column>
+        <key-column>column_name</key-column>
+    </table-ref>
+    <table-ref options="default">
+        <schema-name>information_schema</schema-name>
+        <table-name>tables</table-name>
+        <query-text>SELECT * FROM information_schema."tables"</query-text>
+        <key-column>table_schema</key-column>
+        <key-column>table_name</key-column>
+    </table-ref>
+</ydb-importer>

--- a/scripts/sample-hana.xml
+++ b/scripts/sample-hana.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SAP HANA to YDB importer job configuration example -->
+<ydb-importer>
+    <workers>
+        <reader-pool size="4"/>
+    </workers>
+    <source type="hana">
+        <jdbc-class>com.sap.db.jdbc.Driver</jdbc-class>
+        <!-- For tenant DB connect directly to its port (typically 3{instance}41).
+             For SystemDB use 3{instance}13 or add ?databaseName=TENANT_NAME -->
+        <jdbc-url>jdbc:sap://hostname:39041</jdbc-url>
+        <username>SYSTEM</username>
+        <password>Password1</password>
+    </source>
+    <target type="ydb">
+        <script-file>sample-hana.yql.tmp</script-file>
+        <connection-string>grpcs://ydb.serverless.yandexcloud.net:2135?database=/ru-central1/b1gfvslmokutuvt2g019/etn63999hrinbapmef6g</connection-string>
+        <!--
+        <connection-string>grpcs://hostname.demo.com:2135?database=/local</connection-string>
+        -->
+        <!-- Custom TLS certificate file, if needed
+        <tls-certificate-file>ca.crt</tls-certificate-file>
+        -->
+        <!-- ENV, NONE, STATIC, METADATA, SAKEY -->
+        <auth-mode>ENV</auth-mode>
+        <!-- auth-mode: STATIC
+        <static-login>username</static-login>
+        <static-password>password</static-password>
+        -->
+        <!-- auth-mode: SAKEY
+        <sa-key-file>ydb-sa-keyfile.json</sa-key-file>
+        -->
+        <replace-existing>true</replace-existing>
+        <load-data>true</load-data>
+        <max-batch-rows>1000</max-batch-rows>
+        <max-blob-rows>200</max-blob-rows>
+    </target>
+    <table-options name="default">
+        <!--  ASIS, LOWER, UPPER -->
+        <case-mode>ASIS</case-mode>
+        <!-- Substitution values: ${schema}, ${table} -->
+        <table-name-format>hana1/${schema}/${table}</table-name-format>
+        <!-- Substitution values: ${schema}, ${table}, ${field} -->
+        <blob-name-format>hana1/${schema}/${table}_${field}</blob-name-format>
+        <!-- DATE_NEW, DATE, INT, STR -->
+        <conv-date>DATE_NEW</conv-date>
+        <conv-timestamp>DATE_NEW</conv-timestamp>
+        <allow-custom-decimal>true</allow-custom-decimal>
+        <skip-unknown-types>true</skip-unknown-types>
+    </table-options>
+    <table-map options="default">
+        <include-schemas regexp="true">.*</include-schemas>
+        <!-- Possible extra tags: include-tables, exclude-tables, exclude-schemas -->
+    </table-map>
+    <table-ref options="default">
+        <schema-name>SYS</schema-name>
+        <table-name>TABLES</table-name>
+        <key-column>SCHEMA_NAME</key-column>
+        <key-column>TABLE_NAME</key-column>
+    </table-ref>
+    <table-ref options="default">
+        <schema-name>SYS</schema-name>
+        <table-name>TABLE_COLUMNS</table-name>
+        <query-text>SELECT * FROM SYS.TABLE_COLUMNS</query-text>
+        <key-column>SCHEMA_NAME</key-column>
+        <key-column>TABLE_NAME</key-column>
+        <key-column>COLUMN_NAME</key-column>
+    </table-ref>
+</ydb-importer>

--- a/scripts/sample-mariadb.xml
+++ b/scripts/sample-mariadb.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- MariaDB to YDB importer job configuration example -->
+<ydb-importer>
+    <workers>
+        <reader-pool size="4"/>
+    </workers>
+    <source type="mariadb">
+        <jdbc-class>org.mariadb.jdbc.Driver</jdbc-class>
+        <jdbc-url>jdbc:mariadb://hostname:3306/dbname</jdbc-url>
+        <username>username</username>
+        <password>password</password>
+    </source>
+    <target type="ydb">
+        <script-file>sample-mariadb.yql.tmp</script-file>
+        <connection-string>grpcs://ydb.serverless.yandexcloud.net:2135?database=/ru-central1/b1gfvslmokutuvt2g019/etn63999hrinbapmef6g</connection-string>
+        <!--
+        <connection-string>grpcs://hostname.demo.com:2135?database=/local</connection-string>
+        -->
+        <!-- Custom TLS certificate file, if needed
+        <tls-certificate-file>ca.crt</tls-certificate-file>
+        -->
+        <!-- ENV, NONE, STATIC, METADATA, SAKEY -->
+        <auth-mode>ENV</auth-mode>
+        <!-- auth-mode: STATIC
+        <static-login>username</static-login>
+        <static-password>password</static-password>
+        -->
+        <!-- auth-mode: SAKEY
+        <sa-key-file>ydb-sa-keyfile.json</sa-key-file>
+        -->
+        <replace-existing>true</replace-existing>
+        <load-data>true</load-data>
+        <max-batch-rows>1000</max-batch-rows>
+        <max-blob-rows>200</max-blob-rows>
+    </target>
+    <table-options name="default">
+        <!--  ASIS, LOWER, UPPER -->
+        <case-mode>ASIS</case-mode>
+        <!-- Substitution values: ${schema}, ${table} -->
+        <table-name-format>maria1/${schema}/${table}</table-name-format>
+        <!-- Substitution values: ${schema}, ${table}, ${field} -->
+        <blob-name-format>maria1/${schema}/${table}_${field}</blob-name-format>
+        <!-- DATE_NEW, DATE, INT, STR -->
+        <conv-date>DATE_NEW</conv-date>
+        <conv-timestamp>DATE_NEW</conv-timestamp>
+        <allow-custom-decimal>true</allow-custom-decimal>
+        <skip-unknown-types>true</skip-unknown-types>
+    </table-options>
+    <table-map options="default">
+        <include-schemas regexp="true">.*</include-schemas>
+        <!-- Possible extra tags: include-tables, exclude-tables, exclude-schemas -->
+    </table-map>
+    <table-ref options="default">
+        <schema-name>information_schema</schema-name>
+        <table-name>COLUMNS</table-name>
+        <key-column>TABLE_SCHEMA</key-column>
+        <key-column>TABLE_NAME</key-column>
+        <key-column>COLUMN_NAME</key-column>
+    </table-ref>
+    <table-ref options="default">
+        <schema-name>information_schema</schema-name>
+        <table-name>tables</table-name>
+        <query-text>SELECT * FROM information_schema.`tables`</query-text>
+        <key-column>TABLE_SCHEMA</key-column>
+        <key-column>TABLE_NAME</key-column>
+    </table-ref>
+</ydb-importer>

--- a/scripts/sample-vertica.xml
+++ b/scripts/sample-vertica.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Vertica to YDB importer job configuration example -->
+<ydb-importer>
+    <workers>
+        <reader-pool size="4"/>
+    </workers>
+    <source type="vertica">
+        <jdbc-class>com.vertica.jdbc.Driver</jdbc-class>
+        <jdbc-url>jdbc:vertica://hostname:5433/VMart</jdbc-url>
+        <username>dbadmin</username>
+        <password>password</password>
+    </source>
+    <target type="ydb">
+        <script-file>sample-vertica.yql.tmp</script-file>
+        <connection-string>grpcs://ydb.serverless.yandexcloud.net:2135?database=/ru-central1/b1gfvslmokutuvt2g019/etn63999hrinbapmef6g</connection-string>
+        <!--
+        <connection-string>grpcs://hostname.demo.com:2135?database=/local</connection-string>
+        -->
+        <!-- Custom TLS certificate file, if needed
+        <tls-certificate-file>ca.crt</tls-certificate-file>
+        -->
+        <!-- ENV, NONE, STATIC, METADATA, SAKEY -->
+        <auth-mode>ENV</auth-mode>
+        <!-- auth-mode: STATIC
+        <static-login>username</static-login>
+        <static-password>password</static-password>
+        -->
+        <!-- auth-mode: SAKEY
+        <sa-key-file>ydb-sa-keyfile.json</sa-key-file>
+        -->
+        <replace-existing>true</replace-existing>
+        <load-data>true</load-data>
+        <max-batch-rows>1000</max-batch-rows>
+        <max-blob-rows>200</max-blob-rows>
+    </target>
+    <table-options name="default">
+        <!--  ASIS, LOWER, UPPER -->
+        <case-mode>ASIS</case-mode>
+        <!-- Substitution values: ${schema}, ${table} -->
+        <table-name-format>vert1/${schema}/${table}</table-name-format>
+        <!-- Substitution values: ${schema}, ${table}, ${field} -->
+        <blob-name-format>vert1/${schema}/${table}_${field}</blob-name-format>
+        <!-- DATE_NEW, DATE, INT, STR -->
+        <conv-date>DATE_NEW</conv-date>
+        <conv-timestamp>DATE_NEW</conv-timestamp>
+        <allow-custom-decimal>true</allow-custom-decimal>
+        <skip-unknown-types>true</skip-unknown-types>
+    </table-options>
+    <table-map options="default">
+        <include-schemas regexp="true">.*</include-schemas>
+        <!-- Possible extra tags: include-tables, exclude-tables, exclude-schemas -->
+    </table-map>
+    <table-ref options="default">
+        <schema-name>v_catalog</schema-name>
+        <table-name>tables</table-name>
+        <key-column>table_schema</key-column>
+        <key-column>table_name</key-column>
+    </table-ref>
+    <table-ref options="default">
+        <schema-name>v_catalog</schema-name>
+        <table-name>columns</table-name>
+        <query-text>SELECT * FROM v_catalog.columns</query-text>
+        <key-column>table_schema</key-column>
+        <key-column>table_name</key-column>
+        <key-column>column_name</key-column>
+    </table-ref>
+</ydb-importer>

--- a/src/benchmark/java/tech/ydb/importer/benchmark/VerificationBenchmark.java
+++ b/src/benchmark/java/tech/ydb/importer/benchmark/VerificationBenchmark.java
@@ -250,7 +250,8 @@ public class VerificationBenchmark {
                 "  --pool-size N         importer worker pool size (default 4)",
                 "  --gen-pool-size N     threads for source data loading (default 4)",
                 "  --fetch-size N        JDBC fetchSize (default 10000)",
-                "  --sources LIST        comma-separated from: postgres, mysql, oracle",
+                "  --sources LIST        comma-separated from: postgres, mysql, oracle,",
+                "                        clickhouse, mariadb, vertica, hana, greenplum, db2",
                 "                        (default postgres)",
                 "  --modes LIST          comma-separated from: ROW, ROW+PART, ARROW, ARROW+PART",
                 "                        (default ROW+PART)",
@@ -335,10 +336,25 @@ public class VerificationBenchmark {
             case "postgres":
             case "pg":
                 return SourceDbProfile.postgres(DEFAULT_DB_NAME);
+            case "clickhouse":
+            case "ch":
+                return SourceDbProfile.clickhouse();
+            case "mariadb":
+                return SourceDbProfile.mariadb(DEFAULT_DB_NAME);
+            case "vertica":
+                return SourceDbProfile.vertica();
+            case "hana":
+                return SourceDbProfile.hana();
+            case "greenplum":
+            case "gp":
+                return SourceDbProfile.greenplum();
+            case "db2":
+                return SourceDbProfile.db2();
             default:
                 throw new IllegalArgumentException(
                         "Unknown source: " + name
-                                + ". Use: postgres, mysql, oracle");
+                                + ". Use: postgres, mysql, oracle, clickhouse,"
+                                + " mariadb, vertica, hana, greenplum, db2");
         }
     }
 

--- a/src/main/java/tech/ydb/importer/TableDecision.java
+++ b/src/main/java/tech/ydb/importer/TableDecision.java
@@ -91,7 +91,7 @@ public class TableDecision implements TableIdentity {
             return tableRef.getYdbPartitionCount();
         }
         Integer fromOptions = (options != null) ? options.getYdbPartitionCount() : null;
-        return (fromOptions != null) ? fromOptions : TableRef.AUTO;
+        return (fromOptions != null) ? fromOptions : TableRef.NONE;
     }
 
     public boolean partitionBuffers() {

--- a/src/main/java/tech/ydb/importer/YdbImporter.java
+++ b/src/main/java/tech/ydb/importer/YdbImporter.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,7 +120,12 @@ public class YdbImporter {
                         createMissingTables(workers, tables);
                         // Load data if necessary
                         if (config.getTarget().isLoadData()) {
-                            loadTableData(workers, tables);
+                            invokeBeforeReadHooks(tables);
+                            try {
+                                loadTableData(workers, tables);
+                            } finally {
+                                invokeAfterReadHooks(tables);
+                            }
                         }
                     }
                 }
@@ -243,6 +250,42 @@ public class YdbImporter {
             }
         }
         table.setFields(StructType.of(fields));
+    }
+
+    private void invokeBeforeReadHooks(List<TableDecision> tables) throws SQLException {
+        runReadHooks(tables, true, (con, td) -> {
+            try {
+                tableLister.beforeTableRead(con, td);
+            } catch (SQLException ex) {
+                LOG.warn("beforeTableRead failed for table {}.{}",
+                        td.getSchema(), td.getTable(), ex);
+                td.setFailure(true);
+            }
+        });
+    }
+
+    private void invokeAfterReadHooks(List<TableDecision> tables) throws SQLException {
+        runReadHooks(tables, false, (con, td) -> {
+            try {
+                tableLister.afterTableRead(con, td);
+            } catch (SQLException ex) {
+                LOG.warn("afterTableRead failed for table {}.{}",
+                        td.getSchema(), td.getTable(), ex);
+            }
+        });
+    }
+
+    private void runReadHooks(List<TableDecision> tables, boolean skipFailed,
+            BiConsumer<Connection, TableDecision> action) throws SQLException {
+        try (Connection con = sourceCP.getConnection()) {
+            con.setAutoCommit(true);
+            for (TableDecision td : tables) {
+                if (skipFailed && td.isFailure()) {
+                    continue;
+                }
+                action.accept(con, td);
+            }
+        }
     }
 
     private void loadTableData(ExecutorService es, List<TableDecision> tables) throws Exception {

--- a/src/main/java/tech/ydb/importer/config/SourceType.java
+++ b/src/main/java/tech/ydb/importer/config/SourceType.java
@@ -16,4 +16,5 @@ public enum SourceType {
     CLICKHOUSE,
     MARIADB,
     VERTICA,
+    HANA,
 }

--- a/src/main/java/tech/ydb/importer/config/SourceType.java
+++ b/src/main/java/tech/ydb/importer/config/SourceType.java
@@ -14,4 +14,5 @@ public enum SourceType {
     DB2,
     INFORMIX,
     CLICKHOUSE,
+    MARIADB,
 }

--- a/src/main/java/tech/ydb/importer/config/SourceType.java
+++ b/src/main/java/tech/ydb/importer/config/SourceType.java
@@ -13,4 +13,5 @@ public enum SourceType {
     MSSQL,
     DB2,
     INFORMIX,
+    CLICKHOUSE,
 }

--- a/src/main/java/tech/ydb/importer/config/SourceType.java
+++ b/src/main/java/tech/ydb/importer/config/SourceType.java
@@ -15,4 +15,5 @@ public enum SourceType {
     INFORMIX,
     CLICKHOUSE,
     MARIADB,
+    VERTICA,
 }

--- a/src/main/java/tech/ydb/importer/config/SourceType.java
+++ b/src/main/java/tech/ydb/importer/config/SourceType.java
@@ -17,4 +17,5 @@ public enum SourceType {
     MARIADB,
     VERTICA,
     HANA,
+    GREENPLUM,
 }

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -51,6 +51,12 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
         return cached;
     }
 
+    public void beforeTableRead(Connection con, TableDecision td) throws SQLException {
+    }
+
+    public void afterTableRead(Connection con, TableDecision td) throws SQLException {
+    }
+
     // Safely quote the identifier
     protected abstract String safeId(String id);
 

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -328,6 +328,8 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
                 return new MySqlTableLister(tableMaps);
             case MARIADB:
                 return new MariaDbTableLister(tableMaps);
+            case VERTICA:
+                return new VerticaTableLister(tableMaps);
             case CLICKHOUSE:
                 return new ClickHouseTableLister(tableMaps);
             case INFORMIX:

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -326,6 +326,8 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
                 return new PostgresTableLister(tableMaps);
             case MYSQL:
                 return new MySqlTableLister(tableMaps);
+            case MARIADB:
+                return new MariaDbTableLister(tableMaps);
             case CLICKHOUSE:
                 return new ClickHouseTableLister(tableMaps);
             case INFORMIX:

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -336,8 +336,9 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
                 return new GreenplumTableLister(tableMaps);
             case CLICKHOUSE:
                 return new ClickHouseTableLister(tableMaps);
-            case INFORMIX:
             case DB2:
+                return new DB2TableLister(tableMaps);
+            case INFORMIX:
             case MSSQL:
                 return new GenericJdbcTableLister(tableMaps, con);
             default:

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -332,6 +332,8 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
                 return new VerticaTableLister(tableMaps);
             case HANA:
                 return new HanaTableLister(tableMaps);
+            case GREENPLUM:
+                return new GreenplumTableLister(tableMaps);
             case CLICKHOUSE:
                 return new ClickHouseTableLister(tableMaps);
             case INFORMIX:

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -330,6 +330,8 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
                 return new MariaDbTableLister(tableMaps);
             case VERTICA:
                 return new VerticaTableLister(tableMaps);
+            case HANA:
+                return new HanaTableLister(tableMaps);
             case CLICKHOUSE:
                 return new ClickHouseTableLister(tableMaps);
             case INFORMIX:

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -57,6 +57,10 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
     public void afterTableRead(Connection con, TableDecision td) throws SQLException {
     }
 
+    public boolean useStringForClobRead() {
+        return false;
+    }
+
     // Safely quote the identifier
     protected abstract String safeId(String id);
 
@@ -322,6 +326,8 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
                 return new PostgresTableLister(tableMaps);
             case MYSQL:
                 return new MySqlTableLister(tableMaps);
+            case CLICKHOUSE:
+                return new ClickHouseTableLister(tableMaps);
             case INFORMIX:
             case DB2:
             case MSSQL:

--- a/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
@@ -1,0 +1,222 @@
+package tech.ydb.importer.source;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tech.ydb.importer.TableDecision;
+import tech.ydb.importer.config.TableIdentity;
+
+/**
+ * Source table metadata retrieval - ClickHouse specifics.
+ */
+public class ClickHouseTableLister extends AnyTableLister {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClickHouseTableLister.class);
+
+    public static final Set<String> SKIP_DATABASES;
+    public static final Set<String> SKIP_TABLE_ENGINES;
+
+    static {
+        final Set<String> db = new HashSet<>();
+        db.add("system");
+        db.add("INFORMATION_SCHEMA");
+        db.add("information_schema");
+        SKIP_DATABASES = Collections.unmodifiableSet(db);
+
+        final Set<String> eng = new HashSet<>();
+        eng.add("View");
+        SKIP_TABLE_ENGINES = Collections.unmodifiableSet(eng);
+    }
+
+    public ClickHouseTableLister(TableMapList tableMaps) {
+        super(tableMaps);
+    }
+
+    @Override
+    protected List<String> listSchemas(Connection con) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT name FROM system.databases")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    String value = rs.getString(1);
+                    if (SKIP_DATABASES.contains(value)) {
+                        continue;
+                    }
+                    retval.add(value);
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected List<String> listTables(Connection con, String schema) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT name, engine FROM system.tables "
+                + "WHERE database = ? AND is_temporary = 0 "
+                + "ORDER BY name")) {
+            ps.setString(1, schema);
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    String name = rs.getString(1);
+                    String engine = rs.getString(2);
+                    if (engine != null && SKIP_TABLE_ENGINES.contains(engine)) {
+                        continue;
+                    }
+                    retval.add(name);
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected long grabRowCount(Connection con, TableIdentity ti) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT total_rows FROM system.tables "
+                + "WHERE database = ? AND name = ? AND is_temporary = 0")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long v = rs.getLong(1);
+                    if (!rs.wasNull()) {
+                        return v;
+                    }
+                }
+            }
+        }
+        return -1L;
+    }
+
+    @Override
+    protected List<ColumnInfo> grabColumnNames(Connection con, TableIdentity ti) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT name FROM system.columns "
+                + "WHERE database = ? AND table = ? "
+                + "ORDER BY position")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<ColumnInfo> cols = new ArrayList<>();
+                while (rs.next()) {
+                    cols.add(new ColumnInfo(rs.getString(1)));
+                }
+                return cols;
+            }
+        }
+    }
+
+    @Override
+    protected void grabPrimaryKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        tm.clearKey();
+    }
+
+    @Override
+    public List<TaskInfo> listPartitions(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        if (td.getTableRef() != null && td.getTableRef().hasQueryText()) {
+            return Collections.emptyList();
+        }
+        String schema = td.getSchema();
+        String table = td.getTable();
+        String baseSql = makeSelectSql(schema, table, tm.getColumns());
+        int chunkRows = tableMaps.getConfig().getSource().getFetchSize();
+        final List<TaskInfo> tasks = new ArrayList<>();
+
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT name, rows FROM system.parts "
+                + "WHERE database = ? AND table = ? AND active "
+                + "ORDER BY name")) {
+            ps.setString(1, schema);
+            ps.setString(2, table);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String partName = rs.getString(1);
+                    long rows = rs.getLong(2);
+                    if (rows <= 0) {
+                        continue;
+                    }
+                    List<TaskQuery> queries = new ArrayList<>();
+                    for (long offset = 0; offset < rows; offset += chunkRows) {
+                        long end = Math.min(offset + chunkRows, rows);
+                        String sql = String.format(
+                                "%s WHERE _part = '%s' AND _part_offset >= %d AND _part_offset < %d",
+                                baseSql, partName.replace("'", "''"), offset, end);
+                        String name = schema + "." + table
+                                + "#" + partName + "[" + offset + ":" + end + "]";
+                        queries.add(new TaskQuery(name, sql));
+                    }
+                    tasks.add(new TaskInfo(schema + "." + table + "#" + partName, queries));
+                }
+            }
+        }
+        if (tasks.size() < 2) {
+            return Collections.emptyList();
+        }
+        return tasks;
+    }
+
+    @Override
+    public void beforeTableRead(Connection con, TableDecision td) throws SQLException {
+        String sql = "SYSTEM STOP MERGES " + safeId(td.getSchema()) + "." + safeId(td.getTable());
+        try (Statement stmt = con.createStatement()) {
+            stmt.execute(sql);
+        }
+        LOG.info("Stopped merges for {}.{}", td.getSchema(), td.getTable());
+        refreshPartitionTasks(con, td);
+    }
+
+    private void refreshPartitionTasks(Connection con, TableDecision td) throws SQLException {
+        if (td.getTableRef() != null
+                && (td.getTableRef().hasSplit() || td.getTableRef().hasQueryText())) {
+            return;
+        }
+        if (!td.useSourcePartitions()) {
+            return;
+        }
+        List<TaskInfo> fresh = listPartitions(con, td, td.getMetadata());
+        if (fresh.isEmpty()) {
+            String label = td.getSchema() + "." + td.getTable();
+            fresh = Collections.singletonList(new TaskInfo(label,
+                    makeSelectSql(td.getSchema(), td.getTable(), td.getMetadata().getColumns())));
+        }
+        td.getMetadata().setTasks(fresh);
+    }
+
+    @Override
+    public void afterTableRead(Connection con, TableDecision td) throws SQLException {
+        String sql = "SYSTEM START MERGES " + safeId(td.getSchema()) + "." + safeId(td.getTable());
+        try (Statement stmt = con.createStatement()) {
+            stmt.execute(sql);
+        }
+        LOG.info("Started merges for {}.{}", td.getSchema(), td.getTable());
+    }
+
+    @Override
+    public boolean useStringForClobRead() {
+        return true;
+    }
+
+    @Override
+    protected String safeId(String id) {
+        if (id.contains("`")) {
+            throw new IllegalArgumentException("Backtick within the identifier: " + id);
+        }
+        return "`" + id + "`";
+    }
+}

--- a/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
@@ -126,6 +126,46 @@ public class ClickHouseTableLister extends AnyTableLister {
         tm.clearKey();
     }
 
+    /*
+     * ClickHouse reports UInt64 as OTHER. Read the column type from the catalog and
+     * remap a plain UInt64 to NUMERIC(20,0).
+     */
+    @Override
+    protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        super.grabColumnTypes(con, td, tm);
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT name, type FROM system.columns "
+                + "WHERE database = ? AND table = ?")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ColumnInfo ci = tm.findColumn(rs.getString(1));
+                    if (ci == null || ci.getSqlType() != java.sql.Types.OTHER) {
+                        continue;
+                    }
+                    if (isUInt64Type(rs.getString(2))) {
+                        ci.setSqlType(java.sql.Types.NUMERIC);
+                        ci.setSqlPrecision(20);
+                        ci.setSqlScale(0);
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean isUInt64Type(String type) {
+        if (type == null) {
+            return false;
+        }
+        String inner = type.trim();
+        while (inner.startsWith("LowCardinality(") || inner.startsWith("Nullable(")) {
+            inner = inner.substring(inner.indexOf('(') + 1, inner.length() - 1).trim();
+        }
+        return inner.equals("UInt64");
+    }
+
     @Override
     public List<TaskInfo> listPartitions(Connection con, TableDecision td, TableMetadata tm)
             throws SQLException {

--- a/src/main/java/tech/ydb/importer/source/DB2TableLister.java
+++ b/src/main/java/tech/ydb/importer/source/DB2TableLister.java
@@ -1,0 +1,250 @@
+package tech.ydb.importer.source;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tech.ydb.importer.TableDecision;
+import tech.ydb.importer.config.TableIdentity;
+
+/**
+ * Source table metadata retrieval - DB2 LUW specifics.
+ */
+public class DB2TableLister extends AnyTableLister {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DB2TableLister.class);
+
+    public static final Set<String> SKIP_SCHEMAS;
+
+    static {
+        final Set<String> x = new HashSet<>();
+        x.add("NULLID");
+        x.add("SQLJ");
+        x.add("INFORMATION_SCHEMA");
+        SKIP_SCHEMAS = Collections.unmodifiableSet(x);
+    }
+
+    public DB2TableLister(TableMapList tableMaps) {
+        super(tableMaps);
+    }
+
+    @Override
+    protected List<String> listSchemas(Connection con) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT SCHEMANAME FROM SYSCAT.SCHEMATA")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    String value = rs.getString(1);
+                    if (value == null) {
+                        continue;
+                    }
+                    value = value.trim();
+                    if (value.startsWith("SYS") || value.startsWith("IBM")) {
+                        continue;
+                    }
+                    if (SKIP_SCHEMAS.contains(value)) {
+                        continue;
+                    }
+                    retval.add(value);
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected List<String> listTables(Connection con, String schema) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT TABNAME FROM SYSCAT.TABLES "
+                + "WHERE TABSCHEMA=? AND TYPE='T' "
+                + "ORDER BY TABNAME")) {
+            ps.setString(1, schema);
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    retval.add(rs.getString(1).trim());
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected long grabRowCount(Connection con, TableIdentity ti) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT CARD FROM SYSCAT.TABLES "
+                + "WHERE TABSCHEMA=? AND TABNAME=?")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long retval = rs.getLong(1);
+                    if (!rs.wasNull()) {
+                        return retval;
+                    }
+                }
+            }
+        }
+        return -1L;
+    }
+
+    @Override
+    protected List<ColumnInfo> grabColumnNames(Connection con, TableIdentity ti) throws SQLException {
+        final List<ColumnInfo> cols = new ArrayList<>();
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT COLNAME FROM SYSCAT.COLUMNS "
+                + "WHERE TABSCHEMA=? AND TABNAME=? "
+                + "ORDER BY COLNO")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    cols.add(new ColumnInfo(rs.getString(1).trim()));
+                }
+            }
+        }
+        return cols;
+    }
+
+    @Override
+    protected void grabPrimaryKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        if (grabPrimaryKeyConstraint(con, ti, tm)) {
+            return;
+        }
+        chooseBestUniqueIndexAsKey(con, ti, tm);
+    }
+
+    /**
+     * Retrieve the real PRIMARY KEY definition, if it exists
+     */
+    private boolean grabPrimaryKeyConstraint(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        tm.clearKey();
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT k.COLNAME FROM SYSCAT.TABCONST c "
+                + "JOIN SYSCAT.KEYCOLUSE k "
+                + "  ON c.CONSTNAME=k.CONSTNAME "
+                + " AND c.TABSCHEMA=k.TABSCHEMA "
+                + " AND c.TABNAME=k.TABNAME "
+                + "WHERE c.TABSCHEMA=? AND c.TABNAME=? AND c.TYPE='P' "
+                + "ORDER BY k.COLSEQ")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    tm.addKey(rs.getString(1).trim());
+                }
+            }
+        }
+        return !tm.getKey().isEmpty();
+    }
+
+    /**
+     * Choose the best UNIQUE index when there is no PRIMARY KEY
+     * <p>
+     * (a) Prefer an index with the smallest number of columns
+     * (b) For equal length indexes, order by index name alphabetically
+     * (c) Skip PK indexes (UNIQUERULE='P') and expression indexes
+     */
+    private void chooseBestUniqueIndexAsKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        String bestIndSchema = null;
+        String bestIndName = null;
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT i.INDSCHEMA, i.INDNAME FROM SYSCAT.INDEXES i "
+                + "WHERE i.TABSCHEMA=? AND i.TABNAME=? "
+                + "  AND i.UNIQUERULE='U' "
+                + "  AND NOT EXISTS ("
+                + "      SELECT 1 FROM SYSCAT.INDEXCOLUSE ic "
+                + "      WHERE ic.INDSCHEMA=i.INDSCHEMA AND ic.INDNAME=i.INDNAME "
+                + "        AND ic.COLORDER IN ('A','D') "
+                + "        AND NOT EXISTS ("
+                + "            SELECT 1 FROM SYSCAT.COLUMNS c "
+                + "            WHERE c.TABSCHEMA=i.TABSCHEMA AND c.TABNAME=i.TABNAME "
+                + "              AND c.COLNAME=ic.COLNAME)) "
+                + "ORDER BY i.UNIQUE_COLCOUNT, i.INDNAME "
+                + "FETCH FIRST 1 ROWS ONLY")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    bestIndSchema = rs.getString(1).trim();
+                    bestIndName = rs.getString(2).trim();
+                }
+            }
+        }
+        if (bestIndName == null) {
+            return;
+        }
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT COLNAME FROM SYSCAT.INDEXCOLUSE "
+                + "WHERE INDSCHEMA=? AND INDNAME=? "
+                + "  AND COLORDER IN ('A','D') "
+                + "ORDER BY COLSEQ")) {
+            ps.setString(1, bestIndSchema);
+            ps.setString(2, bestIndName);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    tm.addKey(rs.getString(1).trim());
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<TaskInfo> listPartitions(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        if (td.getTableRef() != null && td.getTableRef().hasQueryText()) {
+            return Collections.emptyList();
+        }
+        if (tm.getColumns().isEmpty()) {
+            return Collections.emptyList();
+        }
+        final List<TaskInfo> partitions = new ArrayList<>();
+        final String baseSql = makeSelectSql(td.getSchema(), td.getTable(), tm.getColumns());
+        // DATAPARTITIONNUM(col) returns the sequence number of the partition
+        // that holds the row. Any column works - use the first one.
+        final String partCol = safeId(tm.getColumns().get(0).getName());
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT SEQNO FROM SYSCAT.DATAPARTITIONS "
+                + "WHERE TABSCHEMA=? AND TABNAME=? "
+                + "ORDER BY SEQNO")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int seqno = rs.getInt(1);
+                    String sql = baseSql
+                            + " WHERE DATAPARTITIONNUM(" + partCol + ") = " + seqno;
+                    String label = td.getSchema() + "." + td.getTable() + "#" + seqno;
+                    partitions.add(new TaskInfo(label, sql));
+                }
+            }
+        }
+        if (partitions.size() < 2) {
+            return Collections.emptyList();
+        }
+        LOG.info("Table {}.{}: found {} partitions",
+                td.getSchema(), td.getTable(), partitions.size());
+        return partitions;
+    }
+
+    @Override
+    protected String safeId(String id) {
+        if (id.contains("\"")) {
+            throw new IllegalArgumentException("Double quotes within the identifier: " + id);
+        }
+        return "\"" + id + "\"";
+    }
+}

--- a/src/main/java/tech/ydb/importer/source/GreenplumTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/GreenplumTableLister.java
@@ -1,0 +1,60 @@
+package tech.ydb.importer.source;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import tech.ydb.importer.TableDecision;
+
+/**
+ * Source table metadata retrieval - Greenplum specifics.
+ */
+public class GreenplumTableLister extends PostgresTableLister {
+
+    private static final Set<String> EXTRA_SKIP_SCHEMAS =
+            Collections.singleton("gp_toolkit");
+
+    public GreenplumTableLister(TableMapList tableMaps) {
+        super(tableMaps);
+    }
+
+    @Override
+    protected List<String> listSchemas(Connection con) throws SQLException {
+        List<String> schemas = super.listSchemas(con);
+        schemas.removeIf(EXTRA_SKIP_SCHEMAS::contains);
+        return schemas;
+    }
+
+    /**
+     * Greenplum reports NOT NULL columns as nullable in ResultSetMetaData.
+     * Restore the flag from pg_attribute.
+     */
+    @Override
+    protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        super.grabColumnTypes(con, td, tm);
+        String sql = "SELECT a.attname "
+                + "FROM pg_class c "
+                + "  JOIN pg_namespace s ON s.oid = c.relnamespace "
+                + "  JOIN pg_attribute a ON a.attrelid = c.oid "
+                + "WHERE s.nspname = ? AND c.relname = ? "
+                + "  AND a.attnum > 0 AND NOT a.attisdropped "
+                + "  AND a.attnotnull";
+        try (PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ColumnInfo ci = tm.findColumn(rs.getString(1));
+                    if (ci != null) {
+                        ci.setNullable(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/tech/ydb/importer/source/HanaTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/HanaTableLister.java
@@ -1,0 +1,262 @@
+package tech.ydb.importer.source;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tech.ydb.importer.TableDecision;
+import tech.ydb.importer.config.TableIdentity;
+
+/**
+ * Source table metadata retrieval - HANA specifics.
+ */
+public class HanaTableLister extends AnyTableLister {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HanaTableLister.class);
+
+    public static final Set<String> SKIP_SCHEMAS;
+
+    static {
+        final Set<String> x = new HashSet<>();
+        x.add("SYS");
+        x.add("PUBLIC");
+        x.add("HANA_XS_BASE");
+        x.add("SYSTEM");
+        SKIP_SCHEMAS = Collections.unmodifiableSet(x);
+    }
+
+    public HanaTableLister(TableMapList tableMaps) {
+        super(tableMaps);
+    }
+
+    @Override
+    protected List<String> listSchemas(Connection con) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT SCHEMA_NAME FROM SYS.SCHEMAS")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    String value = rs.getString(1);
+                    if (value == null || value.startsWith("_SYS")) {
+                        continue;
+                    }
+                    if (SKIP_SCHEMAS.contains(value)) {
+                        continue;
+                    }
+                    retval.add(value);
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected List<String> listTables(Connection con, String schema) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT TABLE_NAME FROM SYS.TABLES "
+                + "WHERE SCHEMA_NAME=? "
+                + "ORDER BY TABLE_NAME")) {
+            ps.setString(1, schema);
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    retval.add(rs.getString(1));
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected long grabRowCount(Connection con, TableIdentity ti) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT RECORD_COUNT FROM SYS.M_TABLES "
+                + "WHERE SCHEMA_NAME=? AND TABLE_NAME=?")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long retval = rs.getLong(1);
+                    if (!rs.wasNull()) {
+                        return retval;
+                    }
+                }
+            }
+        }
+        return -1L;
+    }
+
+    @Override
+    protected List<ColumnInfo> grabColumnNames(Connection con, TableIdentity ti) throws SQLException {
+        final List<ColumnInfo> cols = new ArrayList<>();
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT COLUMN_NAME FROM SYS.TABLE_COLUMNS "
+                + "WHERE SCHEMA_NAME=? AND TABLE_NAME=? "
+                + "ORDER BY POSITION")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    cols.add(new ColumnInfo(rs.getString(1)));
+                }
+            }
+        }
+        return cols;
+    }
+
+    /**
+     * HANA JDBC reports TIMESTAMP with scale=0, which maps to Datetime64
+     * and loses fractional seconds. Tag scale=7 so the mapper picks Timestamp64.
+     */
+    @Override
+    protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        super.grabColumnTypes(con, td, tm);
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT COLUMN_NAME, DATA_TYPE_NAME FROM SYS.TABLE_COLUMNS "
+                + "WHERE SCHEMA_NAME=? AND TABLE_NAME=?")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    if (!"TIMESTAMP".equals(rs.getString(2))) {
+                        continue;
+                    }
+                    ColumnInfo ci = tm.findColumn(rs.getString(1));
+                    if (ci != null && ci.getSqlType() == java.sql.Types.TIMESTAMP) {
+                        ci.setSqlScale(7);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void grabPrimaryKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        if (grabPrimaryKeyConstraint(con, ti, tm)) {
+            return;
+        }
+        chooseBestUniqueConstraintAsKey(con, ti, tm);
+    }
+
+    /**
+     * Retrieve the real PRIMARY KEY definition, if it exists
+     */
+    private boolean grabPrimaryKeyConstraint(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        tm.clearKey();
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT COLUMN_NAME FROM SYS.CONSTRAINTS "
+                + "WHERE SCHEMA_NAME=? AND TABLE_NAME=? "
+                + "  AND IS_PRIMARY_KEY='TRUE' "
+                + "ORDER BY POSITION")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    tm.addKey(rs.getString(1));
+                }
+            }
+        }
+        return !tm.getKey().isEmpty();
+    }
+
+    /**
+     * Choose the best UNIQUE constraint when there is no PRIMARY KEY.
+     * <p>
+     * (a) Prefer a constraint with the smallest number of columns.
+     * (b) For equal length constraints, order by constraint name alphabetically.
+     * <p>
+     * SYS.CONSTRAINTS only lists UNIQUE constraints from CREATE TABLE or
+     * ALTER TABLE. Expression based and partial UNIQUE indexes live in
+     * SYS.INDEXES and do not appear here.
+     */
+    private void chooseBestUniqueConstraintAsKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        String bestConstraint = null;
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT CONSTRAINT_NAME FROM SYS.CONSTRAINTS "
+                + "WHERE SCHEMA_NAME=? AND TABLE_NAME=? "
+                + "  AND IS_UNIQUE_KEY='TRUE' "
+                + "  AND IS_PRIMARY_KEY='FALSE' "
+                + "GROUP BY CONSTRAINT_NAME "
+                + "ORDER BY COUNT(*), CONSTRAINT_NAME "
+                + "LIMIT 1")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    bestConstraint = rs.getString(1);
+                }
+            }
+        }
+        if (bestConstraint == null) {
+            return;
+        }
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT COLUMN_NAME FROM SYS.CONSTRAINTS "
+                + "WHERE SCHEMA_NAME=? AND TABLE_NAME=? AND CONSTRAINT_NAME=? "
+                + "ORDER BY POSITION")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            ps.setString(3, bestConstraint);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    tm.addKey(rs.getString(1));
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<TaskInfo> listPartitions(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        if (td.getTableRef() != null && td.getTableRef().hasQueryText()) {
+            return Collections.emptyList();
+        }
+        final List<TaskInfo> partitions = new ArrayList<>();
+        final String baseSql = makeSelectSql(td.getSchema(), td.getTable(), tm.getColumns());
+        // Row store tables cannot be partitioned. The query returns empty for them
+        // and readMetadata falls back to a single task full scan.
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT PART_ID FROM SYS.TABLE_PARTITIONS "
+                + "WHERE SCHEMA_NAME=? AND TABLE_NAME=? "
+                + "  AND PART_ID > 0 "
+                + "ORDER BY PART_ID")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int partId = rs.getInt(1);
+                    String sql = baseSql + " PARTITION (" + partId + ")";
+                    String label = td.getSchema() + "." + td.getTable() + "#" + partId;
+                    partitions.add(new TaskInfo(label, sql));
+                }
+            }
+        }
+        if (partitions.size() < 2) {
+            return Collections.emptyList();
+        }
+        LOG.info("Table {}.{}: found {} partitions",
+                td.getSchema(), td.getTable(), partitions.size());
+        return partitions;
+    }
+
+    @Override
+    protected String safeId(String id) {
+        if (id.contains("\"")) {
+            throw new IllegalArgumentException("Double quotes within the identifier: " + id);
+        }
+        return "\"" + id + "\"";
+    }
+}

--- a/src/main/java/tech/ydb/importer/source/MariaDbTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/MariaDbTableLister.java
@@ -1,0 +1,124 @@
+package tech.ydb.importer.source;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import tech.ydb.importer.TableDecision;
+import tech.ydb.importer.config.TableIdentity;
+
+/**
+ * Source table metadata retrieval - MariaDB specifics.
+ */
+public class MariaDbTableLister extends MySqlTableLister {
+
+    public static final Set<String> SKIP_SCHEMAS;
+
+    static {
+        final Set<String> x = new HashSet<>();
+        x.add("information_schema");
+        x.add("mysql");
+        x.add("performance_schema");
+        x.add("sys");
+        x.add("calpontsys");
+        x.add("infinidb_querystats");
+        x.add("columnstore_info");
+        SKIP_SCHEMAS = Collections.unmodifiableSet(x);
+    }
+
+    private final Map<String, String> tableEngines = new HashMap<>();
+
+    public MariaDbTableLister(TableMapList tableMaps) {
+        super(tableMaps);
+    }
+
+    @Override
+    protected List<String> listSchemas(Connection con) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT schema_name FROM information_schema.schemata")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    String value = rs.getString(1);
+                    if (SKIP_SCHEMAS.contains(value)) {
+                        continue;
+                    }
+                    retval.add(value);
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected List<String> listTables(Connection con, String schema) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT table_name, engine FROM information_schema.tables "
+                + "WHERE table_schema=? AND table_type='BASE TABLE'")) {
+            ps.setString(1, schema);
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    String tableName = rs.getString(1);
+                    String engine = rs.getString(2);
+                    retval.add(tableName);
+                    if (engine != null) {
+                        tableEngines.put(schema + "." + tableName, engine);
+                    }
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        super.grabColumnTypes(con, td, tm);
+        // Remap MariaDB MEDIUMBLOB/LONGBLOB from VARBINARY to BLOB.
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT column_name FROM information_schema.columns "
+                + "WHERE table_schema=? AND table_name=? "
+                + "  AND data_type IN ('mediumblob', 'longblob')")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ColumnInfo ci = tm.findColumn(rs.getString(1));
+                    if (ci != null && !ColumnInfo.isBlob(ci.getSqlType())) {
+                        ci.setSqlType(java.sql.Types.BLOB);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void grabPrimaryKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        String engine = tableEngines.get(ti.getSchema() + "." + ti.getTable());
+        if (engine != null && engine.equalsIgnoreCase("Columnstore")) {
+            tm.clearKey();
+            return;
+        }
+        super.grabPrimaryKey(con, ti, tm);
+    }
+
+    @Override
+    public List<TaskInfo> listPartitions(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        String engine = tableEngines.get(td.getSchema() + "." + td.getTable());
+        if (engine != null && engine.equalsIgnoreCase("Columnstore")) {
+            return Collections.emptyList();
+        }
+        return super.listPartitions(con, td, tm);
+    }
+}

--- a/src/main/java/tech/ydb/importer/source/SourceCP.java
+++ b/src/main/java/tech/ydb/importer/source/SourceCP.java
@@ -7,6 +7,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import tech.ydb.importer.config.SourceConfig;
+import tech.ydb.importer.config.SourceType;
 
 /**
  * Connection pool wrapper object
@@ -19,7 +20,9 @@ public class SourceCP implements AutoCloseable {
 
     public SourceCP(SourceConfig sc, int poolSize) throws SQLException {
         HikariConfig hc = new HikariConfig();
-        hc.setAutoCommit(false);
+        if (SourceType.CLICKHOUSE != sc.getType()) {
+            hc.setAutoCommit(false);
+        }
         hc.setJdbcUrl(sc.getJdbcUrl());
         hc.setUsername(sc.getUserName());
         hc.setPassword(sc.getPassword());

--- a/src/main/java/tech/ydb/importer/source/VerticaTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/VerticaTableLister.java
@@ -1,0 +1,251 @@
+package tech.ydb.importer.source;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tech.ydb.importer.TableDecision;
+import tech.ydb.importer.config.TableIdentity;
+
+/**
+ * Source table metadata retrieval - Vertica specifics.
+ */
+public class VerticaTableLister extends AnyTableLister {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VerticaTableLister.class);
+
+    public static final Set<String> SKIP_SCHEMAS;
+
+    static {
+        final Set<String> x = new HashSet<>();
+        x.add("v_catalog");
+        x.add("v_monitor");
+        x.add("v_internal");
+        x.add("v_txtindex");
+        x.add("v_func");
+        SKIP_SCHEMAS = Collections.unmodifiableSet(x);
+    }
+
+    public VerticaTableLister(TableMapList tableMaps) {
+        super(tableMaps);
+    }
+
+    @Override
+    protected List<String> listSchemas(Connection con) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT schema_name FROM v_catalog.schemata "
+                + "WHERE NOT is_system_schema")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    String value = rs.getString(1);
+                    if (SKIP_SCHEMAS.contains(value)) {
+                        continue;
+                    }
+                    retval.add(value);
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected List<String> listTables(Connection con, String schema) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT table_name FROM v_catalog.tables "
+                + "WHERE table_schema=? "
+                + "ORDER BY table_name")) {
+            ps.setString(1, schema);
+            try (ResultSet rs = ps.executeQuery()) {
+                final List<String> retval = new ArrayList<>();
+                while (rs.next()) {
+                    retval.add(rs.getString(1));
+                }
+                return retval;
+            }
+        }
+    }
+
+    @Override
+    protected long grabRowCount(Connection con, TableIdentity ti) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT ps.row_count "
+                + "FROM v_monitor.projection_storage ps "
+                + "INNER JOIN v_catalog.projections p "
+                + "  ON ps.projection_id=p.projection_id "
+                + "WHERE ps.anchor_table_schema=? AND ps.anchor_table_name=? "
+                + "  AND p.is_super_projection "
+                + "ORDER BY ps.row_count DESC LIMIT 1")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long retval = rs.getLong(1);
+                    if (!rs.wasNull()) {
+                        return retval;
+                    }
+                }
+            }
+        }
+        return -1L;
+    }
+
+    @Override
+    protected List<ColumnInfo> grabColumnNames(Connection con, TableIdentity ti) throws SQLException {
+        final List<ColumnInfo> cols = new ArrayList<>();
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT column_name FROM v_catalog.columns "
+                + "WHERE table_schema=? AND table_name=? "
+                + "ORDER BY ordinal_position")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    cols.add(new ColumnInfo(rs.getString(1)));
+                }
+            }
+        }
+        return cols;
+    }
+
+    @Override
+    protected void grabPrimaryKey(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        tm.clearKey();
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT column_name FROM v_catalog.primary_keys "
+                + "WHERE table_schema=? AND table_name=? "
+                + "  AND is_enabled "
+                + "ORDER BY ordinal_position")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    tm.addKey(rs.getString(1));
+                }
+            }
+        }
+        if (tm.getKey().isEmpty()) {
+            grabBestEnabledUniqueConstraint(con, ti, tm);
+        }
+    }
+
+    private void grabBestEnabledUniqueConstraint(Connection con, TableIdentity ti, TableMetadata tm)
+            throws SQLException {
+        long bestConstraintId = -1;
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT cc.constraint_id, COUNT(*) AS col_count "
+                + "FROM v_catalog.constraint_columns cc "
+                + "WHERE cc.table_schema=? AND cc.table_name=? "
+                + "  AND cc.constraint_type='u' "
+                + "  AND cc.is_enabled "
+                + "GROUP BY cc.constraint_id, cc.constraint_name "
+                + "ORDER BY col_count, cc.constraint_name, cc.constraint_id "
+                + "LIMIT 1")) {
+            ps.setString(1, ti.getSchema());
+            ps.setString(2, ti.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    bestConstraintId = rs.getLong(1);
+                    if (rs.wasNull()) {
+                        bestConstraintId = -1;
+                    }
+                }
+            }
+        }
+        if (bestConstraintId >= 0) {
+            try (PreparedStatement ps = con.prepareStatement(
+                    "SELECT column_name FROM v_catalog.constraint_columns "
+                    + "WHERE constraint_id=? "
+                    + "ORDER BY column_name")) {
+                ps.setLong(1, bestConstraintId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        tm.addKey(rs.getString(1));
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<TaskInfo> listPartitions(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        if (td.getTableRef() != null && td.getTableRef().hasQueryText()) {
+            return Collections.emptyList();
+        }
+        String partitionExpr = getPartitionExpression(con, td);
+        if (partitionExpr == null || partitionExpr.isEmpty()) {
+            return Collections.emptyList();
+        }
+        final List<TaskInfo> partitions = new ArrayList<>();
+        final String baseSql = makeSelectSql(td.getSchema(), td.getTable(), tm.getColumns());
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT pt.partition_key, SUM(pt.ros_row_count) AS row_count "
+                + "FROM v_monitor.partitions pt "
+                + "INNER JOIN v_catalog.projections p "
+                + "  ON pt.projection_id = p.projection_id "
+                + "INNER JOIN v_monitor.projection_storage ps "
+                + "  ON p.projection_id = ps.projection_id "
+                + "WHERE ps.anchor_table_schema = ? AND ps.anchor_table_name = ? "
+                + "  AND p.is_super_projection "
+                + "GROUP BY pt.partition_key "
+                + "ORDER BY pt.partition_key")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String partKey = rs.getString(1);
+                    if (partKey == null) {
+                        continue;
+                    }
+                    String whereSql = baseSql + " WHERE " + partitionExpr + " = " + partKey;
+                    String name = td.getSchema() + "." + td.getTable() + "#" + partKey;
+                    partitions.add(new TaskInfo(name, whereSql));
+                }
+            }
+        }
+        if (partitions.size() < 2) {
+            return Collections.emptyList();
+        }
+        LOG.info("Table {}.{}: found {} partitions by expression: {}",
+                td.getSchema(), td.getTable(), partitions.size(), partitionExpr);
+        return partitions;
+    }
+
+    private String getPartitionExpression(Connection con, TableDecision td) throws SQLException {
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT partition_expression FROM v_catalog.tables "
+                + "WHERE table_schema = ? AND table_name = ?")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    String expr = rs.getString(1);
+                    if (rs.wasNull() || expr == null) {
+                        return null;
+                    }
+                    return expr.trim();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected String safeId(String id) {
+        if (id.contains("\"")) {
+            throw new IllegalArgumentException("Double quotes within the identifier: " + id);
+        }
+        return "\"" + id + "\"";
+    }
+}

--- a/src/main/java/tech/ydb/importer/source/VerticaTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/VerticaTableLister.java
@@ -208,7 +208,8 @@ public class VerticaTableLister extends AnyTableLister {
                     if (partKey == null) {
                         continue;
                     }
-                    String whereSql = baseSql + " WHERE " + partitionExpr + " = " + partKey;
+                    String escapedKey = partKey.replace("'", "''");
+                    String whereSql = baseSql + " WHERE " + partitionExpr + " = '" + escapedKey + "'";
                     String name = td.getSchema() + "." + td.getTable() + "#" + partKey;
                     partitions.add(new TaskInfo(name, whereSql));
                 }

--- a/src/main/java/tech/ydb/importer/target/ClobReader.java
+++ b/src/main/java/tech/ydb/importer/target/ClobReader.java
@@ -1,7 +1,9 @@
 package tech.ydb.importer.target;
 
 import java.io.Reader;
+import java.io.StringReader;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,10 +39,12 @@ public class ClobReader extends ValueReader {
     private final int posId;
     private final int posPos;
     private final int posVal;
+    private final boolean useStringFallback;
 
     private final List<Value<?>> currentBulk = new ArrayList<>();
 
-    public ClobReader(String tablePath, SessionRetryContext ctx, ProgressCounter progress, int maxClobRecords) {
+    public ClobReader(String tablePath, SessionRetryContext ctx, ProgressCounter progress,
+            int maxClobRecords, boolean useStringFallback) {
         this.upsertOp = new YdbUpsertOp(
                 ctx, tablePath, "clob rows upsert issue for " + tablePath, progress::countBlobRows
         );
@@ -48,6 +52,7 @@ public class ClobReader extends ValueReader {
         this.posId = CLOB_ROW.getMemberIndex("id");
         this.posPos = CLOB_ROW.getMemberIndex("pos");
         this.posVal = CLOB_ROW.getMemberIndex("val");
+        this.useStringFallback = useStringFallback;
     }
 
     public void setNextClobId(long id) {
@@ -56,7 +61,7 @@ public class ClobReader extends ValueReader {
 
     @Override
     public void read(ResultSet rs, int rsIdx, int targetIdx, ValueWriter writer, SynthKey synthKey) throws Exception {
-        try (Reader r = rs.getCharacterStream(rsIdx)) {
+        try (Reader r = openReader(rs, rsIdx)) {
             if (rs.wasNull()) {
                 if (synthKey != null) {
                     synthKey.hashNull();
@@ -72,6 +77,14 @@ public class ClobReader extends ValueReader {
             }
             writer.writeInt64(targetIdx, id);
         }
+    }
+
+    private Reader openReader(ResultSet rs, int rsIdx) throws SQLException {
+        if (useStringFallback) {
+            String s = rs.getString(rsIdx);
+            return s == null ? null : new StringReader(s);
+        }
+        return rs.getCharacterStream(rsIdx);
     }
 
     public void saveClob(PrimitiveValue id, Reader r) throws Exception {

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -144,6 +144,9 @@ public class LoadDataTask implements Callable<Boolean> {
                     checkCancelled();
                     savedRowIndex = rowIndex;
                     TaskQuery query = queries.get(nextQuery);
+                    if (queries.size() > 1) {
+                        LOG.info("Reading range {}", query.getName());
+                    }
                     copied += executeQuery(con, query.getSql());
                     nextQuery++;
                     attempt = 0;

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -54,6 +54,7 @@ public class LoadDataTask implements Callable<Boolean> {
     private final int taskBits;
     private final boolean partitionBuffers;
     private final boolean useArrow;
+    private final boolean useStringForClob;
     private final WriterPool writerPool;
     private long rowIndex;
 
@@ -86,6 +87,7 @@ public class LoadDataTask implements Callable<Boolean> {
         this.taskBits = BlobReader.bitsRequired(tab.getMetadata().getTasks().size());
         this.partitionBuffers = tab.partitionBuffers();
         this.useArrow = owner.getConfig().getWorkers().isUseArrow();
+        this.useStringForClob = owner.getTableLister().useStringForClobRead();
         this.writerPool = writerPool;
         this.rowIndex = 0;
     }
@@ -473,7 +475,8 @@ public class LoadDataTask implements Callable<Boolean> {
             } else if (tab.getClobTargets().containsKey(columnName)) {
                 TargetTable tt = tab.getClobTargets().get(columnName);
                 String clobPath = target.getDatabase() + "/" + tt.getFullName();
-                ValueReader reader = new ClobReader(clobPath, target.getRetryCtx(), progress, maxBlobRows);
+                ValueReader reader = new ClobReader(clobPath, target.getRetryCtx(),
+                        progress, maxBlobRows, useStringForClob);
                 index[i] = new ColumnIndex(ixTarget, reader);
             } else {
                 ValueReader reader = ValueReader.getReader(paramListType.getMemberType(ixTarget), ci.getSqlType());

--- a/src/main/java/tech/ydb/importer/target/ValueReader.java
+++ b/src/main/java/tech/ydb/importer/target/ValueReader.java
@@ -9,6 +9,10 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import tech.ydb.table.values.PrimitiveType;
@@ -20,6 +24,13 @@ import tech.ydb.table.values.Type;
  * @author zinal
  */
 public abstract class ValueReader {
+
+    /** Read as UTC to keep the timestamp from shifting with the JVM zone. */
+    private static final ThreadLocal<Calendar> UTC_CALENDAR =
+            ThreadLocal.withInitial(() -> Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+
+    private static final DateTimeFormatter UTC_TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 
     private static final ValueReader BOOL = new BoolReader(ValueWriter::writeBool);
     private static final ValueReader INT_BOOL = new IntReader((w, i, v) -> w.writeBool(i, v != 0));
@@ -49,9 +60,9 @@ public abstract class ValueReader {
     private static final ValueReader DATETIME = new TimestampReader((w, i, v) -> w.writeDatetime(i, v.toInstant()));
     private static final ValueReader TIMESTAMP = new TimestampReader((w, i, v) -> w.writeTimestamp(i, v.toInstant()));
     private static final ValueReader TS_DATE = new TimestampReader(
-            (w, i, v) -> w.writeDate(i, v.toLocalDateTime().toLocalDate()));
+            (w, i, v) -> w.writeDate(i, v.toInstant().atOffset(ZoneOffset.UTC).toLocalDate()));
     private static final ValueReader TS_DATE32 = new TimestampReader(
-            (w, i, v) -> w.writeDate32(i, v.toLocalDateTime().toLocalDate()));
+            (w, i, v) -> w.writeDate32(i, v.toInstant().atOffset(ZoneOffset.UTC).toLocalDate()));
     private static final ValueReader DATETIME64 = new TimestampReader(
             (w, i, v) -> w.writeDatetime64(i, v.toInstant()));
     private static final ValueReader TIMESTAMP64 = new TimestampReader(
@@ -59,7 +70,8 @@ public abstract class ValueReader {
 
     private static final ValueReader TS_INT64 = new TimestampReader((w, i, v) -> w.writeInt64(i, v.getTime()));
     private static final ValueReader TS_UINT64 = new TimestampReader((w, i, v) -> w.writeUint64(i, v.getTime()));
-    private static final ValueReader TS_STR = new TimestampReader((w, i, v) -> w.writeText(i, v.toString()));
+    private static final ValueReader TS_STR = new TimestampReader(
+            (w, i, v) -> w.writeText(i, UTC_TIMESTAMP_FORMAT.format(v.toInstant())));
 
     private static final ValueReader UUID_BINARY = new UuidReaderBinary();
     private static final ValueReader UUID_TEXT = new UuidReaderText();
@@ -500,7 +512,7 @@ public abstract class ValueReader {
         @Override
         public void read(ResultSet rs, int rsIdx, int targetIdx, ValueWriter writer, SynthKey synthKey)
                 throws Exception {
-            Timestamp value = rs.getTimestamp(rsIdx);
+            Timestamp value = rs.getTimestamp(rsIdx, UTC_CALENDAR.get());
             if (rs.wasNull()) {
                 if (synthKey != null) {
                     synthKey.hashNull();

--- a/src/main/java/tech/ydb/importer/target/YdbTableBuilder.java
+++ b/src/main/java/tech/ydb/importer/target/YdbTableBuilder.java
@@ -35,6 +35,10 @@ public class YdbTableBuilder {
         tab.getClobTargets().clear();
         for (ColumnInfo ci : tab.getMetadata().getColumns()) {
             if (ci.isBlob()) {
+                if (isClobOverride(ci.getName())) {
+                    LOG.warn("ignoring user defined CLOB column {} in table {}: column is BLOB",
+                            ci.getName(), makeTableName());
+                }
                 tab.getBlobTargets().put(ci.getName(),
                         buildAuxTable(ci, "String", BlobReader.BLOB_ROW));
             } else if (ci.isClob()) {

--- a/src/test/java/tech/ydb/importer/integration/common/YdbImporterRunner.java
+++ b/src/test/java/tech/ydb/importer/integration/common/YdbImporterRunner.java
@@ -179,6 +179,7 @@ public final class YdbImporterRunner {
                     targetPrefix + ".${schema}.${table}");
             options.setBlobTemplate(targetPrefix + ".${schema}.${table}_${field}");
             options.setUseSourcePartitions(usePartitions);
+            options.setYdbPartitionCount(usePartitions ? TableRef.AUTO : TableRef.NONE);
             optionsCustomizer.accept(options);
             config.getOptionsMap().put(options.getName(), options);
 

--- a/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseLoader.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseLoader.java
@@ -1,0 +1,58 @@
+package tech.ydb.importer.integration.sources.clickhouse;
+
+import tech.ydb.importer.integration.verification.ColumnSpec;
+import tech.ydb.importer.integration.verification.DialectLoader;
+import tech.ydb.importer.integration.verification.LogicalType;
+import tech.ydb.importer.integration.verification.TableScenario;
+import tech.ydb.importer.integration.verification.TableScenario.PartitionStyle;
+
+public final class ClickHouseLoader extends DialectLoader {
+
+    public static final ClickHouseLoader INSTANCE = new ClickHouseLoader();
+
+    private ClickHouseLoader() {
+    }
+
+    @Override
+    protected String toDdl(LogicalType type) {
+        switch (type) {
+            case INT32:           return "Int32";
+            case INT64:           return "Int64";
+            case DECIMAL_18_4:    return "Decimal(18, 4)";
+            case STRING:          return "String";
+            case BOOL:            return "Bool";
+            case DATE:            return "Date";
+            case DATETIME:        return "DateTime";
+            default:
+                throw new IllegalArgumentException("Unsupported: " + type);
+        }
+    }
+
+    @Override
+    protected String columnDdl(ColumnSpec col) {
+        String base = toDdl(col.type());
+        return col.nullable() ? "Nullable(" + base + ")" : base;
+    }
+
+    @Override
+    protected void appendEngine(StringBuilder ddl, TableScenario scenario) {
+        ddl.append(" ENGINE = MergeTree() ORDER BY ")
+                .append(scenario.keyColumn());
+    }
+
+    @Override
+    protected void appendPartition(StringBuilder ddl, PartitionStyle style,
+                                   String column, TableScenario scenario) {
+        int p = partitionCount(scenario);
+        String expr;
+        switch (style) {
+            case HASH_INT:    expr = "sipHash64(" + column + ") % " + p; break;
+            case RANGE_INT:   expr = column + " % " + p; break;
+            case RANGE_DATE:  expr = "toYear(" + column + ") % " + p; break;
+            case LIST_STRING: expr = column; break;
+            default:
+                throw new IllegalArgumentException("Unsupported: " + style);
+        }
+        ddl.append(" PARTITION BY ").append(expr);
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseTestContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseTestContainer.java
@@ -1,0 +1,15 @@
+package tech.ydb.importer.integration.sources.clickhouse;
+
+import org.testcontainers.clickhouse.ClickHouseContainer;
+
+public final class ClickHouseTestContainer {
+
+    public static final String IMAGE = "clickhouse/clickhouse-server:25.3.10.19";
+
+    private ClickHouseTestContainer() {
+    }
+
+    public static ClickHouseContainer create() {
+        return new ClickHouseContainer(IMAGE);
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
@@ -1,0 +1,558 @@
+package tech.ydb.importer.integration.sources.clickhouse;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+
+import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.config.TableOptions.DateConv;
+import tech.ydb.importer.integration.common.YdbImporterRunner;
+import tech.ydb.importer.integration.common.YdbSchemaReader;
+import tech.ydb.importer.integration.tabletest.AbstractYdbImporterTableTest;
+import tech.ydb.importer.integration.typetest.AbstractYdbImporterTypeTest;
+import tech.ydb.table.values.DecimalType;
+import tech.ydb.table.values.PrimitiveType;
+
+/** ClickHouse integration tests. */
+public class ClickHouseYdbImporterTest {
+
+    private static ClickHouseContainer chContainer;
+    private static TimeZone originalTz;
+
+    @BeforeAll
+    static void startClickHouse() {
+        originalTz = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        chContainer = ClickHouseTestContainer.create();
+        chContainer.start();
+    }
+
+    @AfterAll
+    static void stopClickHouse() {
+        if (chContainer != null) {
+            chContainer.stop();
+            chContainer = null;
+        }
+        if (originalTz != null) {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+
+    abstract class ClickHouseTypeCases extends AbstractYdbImporterTypeTest {
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(chContainer, SourceType.CLICKHOUSE, "default");
+        }
+
+        @Override
+        protected String createTableSuffix() {
+            return " ENGINE = MergeTree() ORDER BY tuple()";
+        }
+
+        @Test
+        public void int32Boundaries() throws Exception {
+            typeTest()
+                    .column("Int32", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("-1", -1)
+                        .value("2147483647", Integer.MAX_VALUE)
+                        .value("-2147483648", Integer.MIN_VALUE)
+                    .column("Nullable(Int32)", PrimitiveType.Int32.makeOptional())
+                        .value("42", 42)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void int64Boundaries() throws Exception {
+            typeTest()
+                    .column("Int64", PrimitiveType.Int64)
+                        .value("0", 0L)
+                        .value("9223372036854775807", Long.MAX_VALUE)
+                        .value("-9223372036854775808", Long.MIN_VALUE)
+                    .execute();
+        }
+
+        @Test
+        public void int8AndInt16MapToInt32() throws Exception {
+            typeTest()
+                    .column("Int8", PrimitiveType.Int32)
+                        .value("127", 127)
+                        .value("-128", -128)
+                    .column("Int16", PrimitiveType.Int32)
+                        .value("32767", 32767)
+                        .value("-32768", -32768)
+                    .execute();
+        }
+
+        @Test
+        public void uint8MapsToInt32() throws Exception {
+            typeTest()
+                    .column("UInt8", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("255", 255)
+                    .execute();
+        }
+
+        @Test
+        public void uint16MapsToInt32() throws Exception {
+            typeTest()
+                    .column("UInt16", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("65535", 65535)
+                    .execute();
+        }
+
+        @Test
+        public void uint32MapsToInt64() throws Exception {
+            typeTest()
+                    .column("UInt32", PrimitiveType.Int64)
+                        .value("0", 0L)
+                        .value("4294967295", 4294967295L)
+                    .execute();
+        }
+
+        @Test
+        public void uint64MapsToDecimal() throws Exception {
+            typeTest()
+                    .column("UInt64", DecimalType.of(35, 0))
+                        .value("0", new BigDecimal("0"))
+                        .value("18446744073709551615",
+                               new BigDecimal("18446744073709551615"))
+                    .execute();
+        }
+
+        @Test
+        public void floatAndDouble() throws Exception {
+            typeTest()
+                    .column("Float32", PrimitiveType.Float)
+                        .value("1.5", 1.5f)
+                        .value("-0.25", -0.25f)
+                    .column("Float64", PrimitiveType.Double)
+                        .value("1.5", 1.5d)
+                        .value("1e100", 1e100d)
+                    .column("Nullable(Float64)",
+                            PrimitiveType.Double.makeOptional())
+                        .value("3.14", 3.14d)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void floatNanAndInfinity() throws Exception {
+            typeTest()
+                    .column("Float32", PrimitiveType.Float)
+                        .value("nan", Float.NaN)
+                        .value("inf", Float.POSITIVE_INFINITY)
+                        .value("-inf", Float.NEGATIVE_INFINITY)
+                    .execute();
+        }
+
+        @Test
+        public void stringTypesMapToText() throws Exception {
+            typeTest()
+                    .column("String", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("''", "")
+                    .column("Nullable(String)",
+                            PrimitiveType.Text.makeOptional())
+                        .value("'hello'", "hello")
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void stringTypesPreserveUnicode() throws Exception {
+            typeTest()
+                    .column("String", PrimitiveType.Text)
+                        .value("'кириллица'", "кириллица")
+                        .value("'emoji \uD83D\uDE00'", "emoji \uD83D\uDE00")
+                    .execute();
+        }
+
+        @Test
+        public void enum8MapsToTextLabel() throws Exception {
+            typeTest()
+                    .column("Enum8('alpha'=1, 'beta'=2)", PrimitiveType.Text)
+                        .value("'alpha'", "alpha")
+                        .value("'beta'", "beta")
+                    .execute();
+        }
+
+        @Test
+        public void fixedStringMapsToText() throws Exception {
+            typeTest()
+                    .column("FixedString(10)", PrimitiveType.Text)
+                        .value("'hello'", "hello\0\0\0\0\0")
+                    .execute();
+        }
+
+        @Test
+        public void lowCardinalityStringMapsToText() throws Exception {
+            typeTest()
+                    .column("LowCardinality(String)", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("'world'", "world")
+                    .execute();
+        }
+
+        @Test
+        public void booleanMaps() throws Exception {
+            typeTest()
+                    .column("Bool", PrimitiveType.Bool)
+                        .value("true", true)
+                        .value("false", false)
+                    .execute();
+        }
+
+        @Test
+        public void scaledDecimalMapsToDecimal() throws Exception {
+            typeTest()
+                    .column("Decimal(10, 4)", DecimalType.of(10, 4))
+                        .value("123.4567", new BigDecimal("123.4567"))
+                        .value("-999999.9999", new BigDecimal("-999999.9999"))
+                        .value("0", new BigDecimal("0.0000"))
+                    .column("Nullable(Decimal(10, 2))",
+                            DecimalType.of(10, 2).makeOptional())
+                        .value("99.99", new BigDecimal("99.99"))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void zeroScaleDecimalMapsToInt32() throws Exception {
+            typeTest()
+                    .column("Decimal(5, 0)", PrimitiveType.Int32)
+                        .value("12345", 12345)
+                        .value("-99999", -99999)
+                    .execute();
+        }
+
+        @Test
+        public void zeroScaleDecimalMapsToInt64() throws Exception {
+            typeTest()
+                    .column("Decimal(15, 0)", PrimitiveType.Int64)
+                        .value("999999999999999", 999999999999999L)
+                        .value("-999999999999999", -999999999999999L)
+                    .execute();
+        }
+
+        @Test
+        public void highPrecisionDecimalMapsToDecimal() throws Exception {
+            typeTest()
+                    .column("Decimal(20, 0)", DecimalType.of(35, 0))
+                        .value("12345678901234567890",
+                               new BigDecimal("12345678901234567890"))
+                    .execute();
+        }
+
+        @Test
+        public void defaultDecimalTypeWhenCustomDisabled() throws Exception {
+            typeTest()
+                    .withOptions(opts -> opts.setAllowCustomDecimal(false))
+                    .column("Decimal(10, 4)", DecimalType.getDefault())
+                        .value("123.4567", new BigDecimal("123.4567"))
+                    .execute();
+        }
+
+        @Test
+        public void dateTypes() throws Exception {
+            typeTest()
+                    .column("Date", PrimitiveType.Date32)
+                        .value("'1970-01-01'", LocalDate.of(1970, 1, 1))
+                        .value("'2024-01-15'", LocalDate.of(2024, 1, 15))
+                        .value("'2106-02-07'", LocalDate.of(2106, 2, 7))
+                    .column("Date32", PrimitiveType.Date32)
+                        .value("'1925-01-01'", LocalDate.of(1925, 1, 1))
+                        .value("'1900-03-15'", LocalDate.of(1900, 3, 15))
+                    .column("Nullable(Date)",
+                            PrimitiveType.Date32.makeOptional())
+                        .value("'2024-01-15'", LocalDate.of(2024, 1, 15))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void dateAsInt() throws Exception {
+            typeTest()
+                    .withOptions(opts -> opts.setDateConv(DateConv.INT))
+                    .column("Date", PrimitiveType.Int32)
+                        .value("'1970-01-01'", 19700101)
+                        .value("'2024-01-15'", 20240115)
+                    .execute();
+        }
+
+        @Test
+        public void dateAsText() throws Exception {
+            typeTest()
+                    .withOptions(opts -> opts.setDateConv(DateConv.STR))
+                    .column("Date", PrimitiveType.Text)
+                        .value("'1970-01-01'", "1970/01/01")
+                        .value("'2024-01-15'", "2024/01/15")
+                    .execute();
+        }
+
+        @Test
+        public void datetimeMapsToDatetime64() throws Exception {
+            typeTest()
+                    .column("DateTime", PrimitiveType.Datetime64)
+                        .value("'2024-01-15 10:30:45'",
+                                java.time.LocalDateTime.of(2024, 1, 15, 10, 30, 45))
+                    .execute();
+        }
+
+        @Test
+        public void timestampMapsToTimestamp64() throws Exception {
+            typeTest()
+                    .column("DateTime64(3, 'UTC')", PrimitiveType.Timestamp64)
+                        .value("toDateTime64('2024-01-15 10:30:45.123', 3, 'UTC')",
+                               java.time.Instant.parse("2024-01-15T10:30:45.123Z"))
+                    .column("DateTime64(6, 'UTC')", PrimitiveType.Timestamp64)
+                        .value("toDateTime64('2024-01-15 10:30:45.123456', 6, 'UTC')",
+                               java.time.Instant.parse("2024-01-15T10:30:45.123456Z"))
+                    .execute();
+        }
+
+    }
+
+    @Nested class TypeTestsRow extends ClickHouseTypeCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TypeTestsArrow extends ClickHouseTypeCases {
+        @Override public boolean useArrow() { return true; }
+    }
+
+    abstract class ClickHouseTableCases extends AbstractYdbImporterTableTest {
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(chContainer, SourceType.CLICKHOUSE, "default");
+        }
+
+        void cleanup(String... sourceQualifiedNames) {
+            try (Connection con = openSourceConnection();
+                 Statement st = con.createStatement()) {
+                for (String name : sourceQualifiedNames) {
+                    st.execute("DROP TABLE IF EXISTS " + name);
+                }
+            } catch (Exception ignored) { }
+            try (YdbSchemaReader ydb = new YdbSchemaReader(
+                    ydbContainer().getConnectionString())) {
+                for (String name : sourceQualifiedNames) {
+                    ydb.dropTable(YdbImporterRunner.DEFAULT_TARGET_PREFIX
+                            + "." + name);
+                }
+            } catch (Exception ignored) { }
+        }
+
+        @Test
+        public void compositeOrderByStillUsesSyntheticKey() throws Exception {
+            tableTest("default", "composite_order")
+                    
+                    .columns("a Int32, b Int32, payload String")
+                    .tableSuffix("ENGINE = MergeTree() ORDER BY (a, b)")
+                    .values("(1, 10, 'x'), (2, 20, 'y'), (3, 30, 'z')")
+                    .expectSyntheticKey()
+                    .expectRowCount(3)
+                    .expectRowExists("a", 1, "b", 10, "payload", "x")
+                    .run();
+        }
+
+        @Test
+        public void partitionedWithChunking() throws Exception {
+            tableTest("default", "chunked")
+                    
+                    .fetchSize(2)
+                    .columns("id Int32, region_id Int32, val String")
+                    .tableSuffix("ENGINE = MergeTree()"
+                            + " PARTITION BY intDiv(region_id, 25)"
+                            + " ORDER BY id")
+                    .values("(1,1,'a'),(2,2,'b'),(3,3,'c'),"
+                            + "(4,25,'d'),(5,26,'e'),(6,27,'f'),"
+                            + "(7,28,'g'),"
+                            + "(8,50,'h'),(9,51,'i'),"
+                            + "(10,75,'j'),(11,76,'k'),"
+                            + "(12,77,'l'),(13,78,'m')")
+                    .expectSyntheticKey()
+                    .expectRowCount(13)
+                    .expectRowExists("id", 1, "val", "a")
+                    .expectRowExists("id", 13, "val", "m")
+                    .run();
+        }
+
+        @Test
+        public void skipUnsupportedColumns() throws Exception {
+            tableTest("default", "skip_all")
+                    
+                    .withOptions(opts -> opts.setSkipUnknownTypes(true))
+                    .columns("id Int32, name String,"
+                            + " tags Array(String),"
+                            + " props Map(String, Int32),"
+                            + " pair Tuple(Int32, String),"
+                            + " uid UUID, ip4 IPv4, ip6 IPv6")
+                    .tableSuffix("ENGINE = MergeTree() ORDER BY id")
+                    .values("(1,'a',['x'],{'k':1},(10,'x'),"
+                            + "generateUUIDv4(),'127.0.0.1','::1'),"
+                            + "(2,'b',['y'],{'k':2},(20,'y'),"
+                            + "generateUUIDv4(),'10.0.0.1','fe80::1')")
+                    .expectSyntheticKey()
+                    .expectSkippedColumns("tags", "props", "pair",
+                            "uid", "ip4", "ip6")
+                    .expectRowCount(2)
+                    .expectRowExists("id", 1, "name", "a")
+                    .expectRowExists("id", 2, "name", "b")
+                    .run();
+        }
+
+        @Test
+        public void variousEngines() throws Exception {
+            importTogether()
+                    
+                    .add(tableTest("default", "eng_rmt")
+                            .columns("id Int32, val String, version Int32")
+                            .tableSuffix("ENGINE = ReplacingMergeTree(version)"
+                                    + " ORDER BY id")
+                            .values("(1,'a',1),(2,'b',1)")
+                            .expectSyntheticKey()
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1, "val", "a")
+                            .expectRowExists("id", 2, "val", "b"))
+                    .add(tableTest("default", "eng_log")
+                            .columns("id Int32, val String")
+                            .tableSuffix("ENGINE = Log")
+                            .values("(1,'x'),(2,'y')")
+                            .expectSyntheticKey()
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1, "val", "x")
+                            .expectRowExists("id", 2, "val", "y"))
+                    .add(tableTest("default", "eng_mem")
+                            .columns("id Int32, val String")
+                            .tableSuffix("ENGINE = Memory")
+                            .values("(1,'p'),(2,'q')")
+                            .expectSyntheticKey()
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1, "val", "p")
+                            .expectRowExists("id", 2, "val", "q"))
+                    .run();
+        }
+
+        @Test
+        public void emptyTableCreatesSchema() throws Exception {
+            tableTest("default", "empty")
+                    
+                    .columns("id Int32, val String")
+                    .tableSuffix("ENGINE = MergeTree() ORDER BY id")
+                    .expectSyntheticKey()
+                    .expectRowCount(0)
+                    .run();
+        }
+
+        @Test
+        public void customQueryTextImport() throws Exception {
+            tableTest("default", "query_src")
+                    
+                    .columns("id Int32, val String")
+                    .tableSuffix("ENGINE = MergeTree() ORDER BY id")
+                    .values("(1,'a'),(2,'b'),(3,'c'),(4,'d')")
+                    .queryText("SELECT id, val FROM default.query_src"
+                            + " WHERE id <= 2")
+                    .expectSyntheticKey()
+                    .expectRowCount(2)
+                    .expectRowExists("id", 1, "val", "a")
+                    .expectRowExists("id", 2, "val", "b")
+                    .run();
+        }
+
+        @Test
+        public void syntheticKeyDistinguishesRows() throws Exception {
+            tableTest("default", "synth_key_test")
+                    
+                    .columns("id Int32, name String")
+                    .tableSuffix("ENGINE = MergeTree() ORDER BY id")
+                    .values("(1,'same'),(2,'same'),(3,'same')")
+                    .expectSyntheticKey()
+                    .expectRowCount(3)
+                    .expectRowExists("id", 1, "name", "same")
+                    .expectRowExists("id", 2, "name", "same")
+                    .expectRowExists("id", 3, "name", "same")
+                    .run();
+        }
+
+        @Test
+        public void multiTablePartitionedImport() throws Exception {
+            importTogether()
+                    
+                    .add(tableTest("default", "mt_sales")
+                            .columns("sale_id Int32, region_id Int32,"
+                                    + " amount Int32")
+                            .tableSuffix("ENGINE = MergeTree()"
+                                    + " PARTITION BY intDiv(region_id, 50)"
+                                    + " ORDER BY sale_id")
+                            .values("(1,10,100),(2,60,200),(3,90,300)")
+                            .expectSyntheticKey()
+                            .expectRowCount(3)
+                            .expectRowExists("sale_id", 1, "amount", 100)
+                            .expectRowExists("sale_id", 3, "amount", 300))
+                    .add(tableTest("default", "mt_events")
+                            .columns("id Int32, ts Date")
+                            .tableSuffix("ENGINE = MergeTree()"
+                                    + " PARTITION BY toYYYYMM(ts)"
+                                    + " ORDER BY id")
+                            .values("(1,'2024-01-15'),(2,'2024-02-20')")
+                            .expectSyntheticKey()
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1)
+                            .expectRowExists("id", 2))
+                    .run();
+        }
+
+        @Test
+        public void clobContentImport() throws Exception {
+            String bigText = repeat("Y", 524_288);
+
+            tableTest("default", "clob_docs")
+                    .setupSql(
+                        "CREATE TABLE default.clob_docs ("
+                        + "  id    Int32,"
+                        + "  short String,"
+                        + "  large String"
+                        + ") ENGINE = MergeTree() ORDER BY id;"
+                        + "INSERT INTO default.clob_docs VALUES"
+                        + " (1, 'YDB', '" + bigText + "'),"
+                        + " (2, '', '')")
+                    .cleanupSql("DROP TABLE IF EXISTS default.clob_docs")
+                    .clobColumns("short", "large")
+                    .expectSyntheticKey()
+                    .expectRowCount(2)
+                    .expectClobColumn("short")
+                    .expectClobColumn("large")
+                    .expectClobContent("short", "id", 1, "YDB")
+                    .expectClobContent("large", "id", 1, bigText)
+                    .expectClobContent("short", "id", 2, "")
+                    .expectClobContent("large", "id", 2, "")
+                    .run();
+        }
+    }
+
+    @Nested class TableTestsRow extends ClickHouseTableCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TableTestsArrow extends ClickHouseTableCases {
+        @Override public boolean useArrow() { return true; }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
@@ -30,7 +30,7 @@ public class ClickHouseYdbImporterTest {
     @BeforeAll
     static void startClickHouse() {
         originalTz = TimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+6"));
         chContainer = ClickHouseTestContainer.create();
         chContainer.start();
     }

--- a/src/test/java/tech/ydb/importer/integration/sources/db2/Db2Loader.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/db2/Db2Loader.java
@@ -1,0 +1,103 @@
+package tech.ydb.importer.integration.sources.db2;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.EnumSet;
+import java.util.Set;
+
+import tech.ydb.importer.integration.verification.DialectLoader;
+import tech.ydb.importer.integration.verification.LogicalType;
+import tech.ydb.importer.integration.verification.TableScenario.PartitionStyle;
+import tech.ydb.importer.integration.verification.TableScenario;
+
+public final class Db2Loader extends DialectLoader {
+
+    public static final Db2Loader INSTANCE = new Db2Loader();
+
+    private Db2Loader() {
+    }
+
+    @Override
+    protected String toDdl(LogicalType type) {
+        switch (type) {
+            case INT32:           return "INTEGER";
+            case INT64:           return "BIGINT";
+            case DECIMAL_18_4:    return "DECIMAL(18, 4)";
+            case STRING:          return "VARCHAR(255)";
+            case BOOL:            return "BOOLEAN";
+            case DATE:            return "DATE";
+            case DATETIME:        return "TIMESTAMP";
+            default:
+                throw new IllegalArgumentException("Unsupported: " + type);
+        }
+    }
+
+    @Override
+    protected String blobDdlType() {
+        return "BLOB";
+    }
+
+    @Override
+    public Set<PartitionStyle> supportedPartitions() {
+        return EnumSet.of(PartitionStyle.RANGE_INT, PartitionStyle.RANGE_DATE);
+    }
+
+    @Override
+    public int loaderPoolSize() {
+        return 1;
+    }
+
+    @Override
+    protected int partitionCount(TableScenario scenario) {
+        return 4;
+    }
+
+    @Override
+    protected void appendPartition(StringBuilder ddl, PartitionStyle style,
+                                   String column, TableScenario scenario) {
+        switch (style) {
+            case RANGE_INT: {
+                long[] b = rangeIntBoundaries(scenario);
+                ddl.append(" PARTITION BY RANGE(").append(column).append(") (");
+                for (int i = 0; i < b.length; i++) {
+                    if (i == 0) {
+                        ddl.append("PARTITION p0 STARTING FROM (0) ");
+                    } else {
+                        ddl.append("PARTITION p").append(i).append(' ');
+                    }
+                    ddl.append("ENDING AT (").append(b[i]).append("),");
+                }
+                ddl.append("PARTITION pmax ENDING AT (MAXVALUE))");
+                break;
+            }
+            case RANGE_DATE:
+                ddl.append(" PARTITION BY RANGE(").append(column).append(")")
+                        .append(" (PARTITION p2024 STARTING FROM")
+                        .append(" ('2024-01-01') ENDING AT ('2025-01-01'),")
+                        .append(" PARTITION p2025 ENDING AT ('2026-01-01'),")
+                        .append(" PARTITION p2026 ENDING AT ('2027-01-01'),")
+                        .append(" PARTITION pmax ENDING AT (MAXVALUE))");
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    protected String createTablePrefix() {
+        return "CREATE TABLE ";
+    }
+
+    @Override
+    public String adaptTableName(String name) {
+        return name.toUpperCase();
+    }
+
+    @Override
+    public void onConnectionOpened(Connection conn, String schema) throws SQLException {
+        try (Statement st = conn.createStatement()) {
+            st.execute("SET CURRENT SCHEMA " + schema);
+        }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/db2/Db2TestContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/db2/Db2TestContainer.java
@@ -1,0 +1,34 @@
+package tech.ydb.importer.integration.sources.db2;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+
+import org.testcontainers.db2.Db2Container;
+
+public final class Db2TestContainer extends Db2Container {
+
+    public static final String IMAGE = "icr.io/db2_community/db2:12.1.4.0";
+    public static final String SCHEMA = "IMPORT_TEST";
+
+    public Db2TestContainer() {
+        super(IMAGE);
+        acceptLicense();
+        withStartupTimeout(Duration.ofMinutes(15));
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        try (Connection c = DriverManager.getConnection(
+                getJdbcUrl(), getUsername(), getPassword());
+             Statement st = c.createStatement()) {
+            st.execute("CREATE SCHEMA " + SCHEMA);
+        } catch (SQLException e) {
+            throw new RuntimeException(
+                    "Failed to create schema " + SCHEMA, e);
+        }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/db2/Db2YdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/db2/Db2YdbImporterTest.java
@@ -1,0 +1,623 @@
+package tech.ydb.importer.integration.sources.db2;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.config.TableOptions.DateConv;
+import tech.ydb.importer.integration.tabletest.AbstractYdbImporterTableTest;
+import tech.ydb.importer.integration.typetest.AbstractYdbImporterTypeTest;
+import tech.ydb.importer.integration.typetest.TypeTestBuilder;
+import tech.ydb.table.values.DecimalType;
+import tech.ydb.table.values.PrimitiveType;
+
+/** IBM Db2 integration tests. */
+public class Db2YdbImporterTest {
+
+    private static Db2TestContainer db2Container;
+    private static TimeZone originalTz;
+
+    @BeforeAll
+    static void startDb2() {
+        originalTz = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        db2Container = new Db2TestContainer();
+        db2Container.start();
+    }
+
+    @AfterAll
+    static void stopDb2() {
+        if (db2Container != null) {
+            db2Container.stop();
+            db2Container = null;
+        }
+        if (originalTz != null) {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+
+    abstract class Db2TypeCases extends AbstractYdbImporterTypeTest {
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(db2Container, SourceType.DB2, "IMPORT_TEST");
+        }
+
+        @Override
+        protected TypeTestBuilder typeTest() {
+            return super.typeTest().withIdentifierQuote("\"");
+        }
+
+        @Test
+        public void smallintMapsToInt32() throws Exception {
+            typeTest()
+                    .column("SMALLINT NOT NULL", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("32767", 32767)
+                        .value("-32768", -32768)
+                    .column("SMALLINT", PrimitiveType.Int32.makeOptional())
+                        .value("42", 42)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void integerBoundaries() throws Exception {
+            typeTest()
+                    .column("INTEGER NOT NULL", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("2147483647", Integer.MAX_VALUE)
+                        .value("-2147483648", Integer.MIN_VALUE)
+                    .column("INTEGER", PrimitiveType.Int32.makeOptional())
+                        .value("42", 42)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void bigintBoundaries() throws Exception {
+            typeTest()
+                    .column("BIGINT NOT NULL", PrimitiveType.Int64)
+                        .value("0", 0L)
+                        .value("9223372036854775807", Long.MAX_VALUE)
+                        .value("-9223372036854775808", Long.MIN_VALUE)
+                    .execute();
+        }
+
+        @Test
+        public void realMapsToFloat() throws Exception {
+            typeTest()
+                    .column("REAL NOT NULL", PrimitiveType.Float)
+                        .value("1.5", 1.5f)
+                        .value("-0.25", -0.25f)
+                    .execute();
+        }
+
+        @Test
+        public void doubleMapsToDouble() throws Exception {
+            typeTest()
+                    .column("DOUBLE NOT NULL", PrimitiveType.Double)
+                        .value("1.5", 1.5d)
+                        .value("1e100", 1e100d)
+                    .column("DOUBLE", PrimitiveType.Double.makeOptional())
+                        .value("9.99", 9.99d)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void decimalWithScale() throws Exception {
+            typeTest()
+                    .column("DECIMAL(10, 4) NOT NULL",
+                            DecimalType.of(10, 4))
+                        .value("123.4567", new BigDecimal("123.4567"))
+                        .value("-999999.9999",
+                                new BigDecimal("-999999.9999"))
+                    .column("DECIMAL(10, 2)",
+                            DecimalType.of(10, 2).makeOptional())
+                        .value("99.99", new BigDecimal("99.99"))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void decimalZeroScaleToInt32() throws Exception {
+            typeTest()
+                    .column("DECIMAL(5, 0) NOT NULL", PrimitiveType.Int32)
+                        .value("12345", 12345)
+                        .value("-99999", -99999)
+                    .execute();
+        }
+
+        @Test
+        public void decimalZeroScaleBigToInt64() throws Exception {
+            typeTest()
+                    .column("DECIMAL(15, 0) NOT NULL", PrimitiveType.Int64)
+                        .value("123456789012345", 123456789012345L)
+                    .execute();
+        }
+
+        @Test
+        public void varcharMaps() throws Exception {
+            typeTest()
+                    .column("VARCHAR(100) NOT NULL", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("''", "")
+                        .value("'кириллица'", "кириллица")
+                    .column("VARCHAR(100)",
+                            PrimitiveType.Text.makeOptional())
+                        .value("'hello'", "hello")
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void charPaddedToText() throws Exception {
+            typeTest()
+                    .column("CHAR(5) NOT NULL", PrimitiveType.Text)
+                        .value("'abc'", "abc  ")
+                        .value("'xyz'", "xyz  ")
+                    .execute();
+        }
+
+        @Test
+        public void varbinaryMapsToBytes() throws Exception {
+            typeTest()
+                    .column("VARBINARY(100) NOT NULL", PrimitiveType.Bytes)
+                        .value("BX'DEADBEEF'",
+                                new byte[]{(byte) 0xDE, (byte) 0xAD,
+                                           (byte) 0xBE, (byte) 0xEF})
+                        .value("BX'00'", new byte[]{(byte) 0x00})
+                    .execute();
+        }
+
+        @Test
+        public void varcharForBitDataMapsToBytes() throws Exception {
+            typeTest()
+                    .column("VARCHAR(100) FOR BIT DATA NOT NULL",
+                            PrimitiveType.Bytes)
+                        .value("BX'DEADBEEF'",
+                                new byte[]{(byte) 0xDE, (byte) 0xAD,
+                                           (byte) 0xBE, (byte) 0xEF})
+                    .execute();
+        }
+
+        @Test
+        public void booleanMaps() throws Exception {
+            typeTest()
+                    .column("BOOLEAN NOT NULL", PrimitiveType.Bool)
+                        .value("TRUE", true)
+                        .value("FALSE", false)
+                    .column("BOOLEAN", PrimitiveType.Bool.makeOptional())
+                        .value("TRUE", true)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void dateMaps() throws Exception {
+            typeTest()
+                    .column("DATE NOT NULL", PrimitiveType.Date32)
+                        .value("'1970-01-01'",
+                                LocalDate.of(1970, 1, 1))
+                        .value("'2024-01-15'",
+                                LocalDate.of(2024, 1, 15))
+                    .column("DATE", PrimitiveType.Date32.makeOptional())
+                        .value("'2024-01-15'",
+                                LocalDate.of(2024, 1, 15))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void dateAsInt() throws Exception {
+            typeTest()
+                    .withOptions(
+                            opts -> opts.setDateConv(DateConv.INT))
+                    .column("DATE NOT NULL", PrimitiveType.Int32)
+                        .value("'1970-01-01'", 19700101)
+                        .value("'2024-01-15'", 20240115)
+                    .execute();
+        }
+
+        @Test
+        public void timeMapsToInt32() throws Exception {
+            typeTest()
+                    .column("TIME NOT NULL", PrimitiveType.Int32)
+                        .value("'00:00:00'", 0)
+                        .value("'10:30:45'", 37845)
+                        .value("'23:59:59'", 86399)
+                    .execute();
+        }
+
+        @Test
+        public void timestampDefaultMaps() throws Exception {
+            // Default TIMESTAMP has fractional precision 6. Scale>0 picks Timestamp64.
+            typeTest()
+                    .column("TIMESTAMP NOT NULL", PrimitiveType.Timestamp64)
+                        .value("'2024-01-15 10:30:45'",
+                                java.time.Instant.parse(
+                                        "2024-01-15T10:30:45Z"))
+                        .value("'2024-01-15 10:30:45.123456'",
+                                java.time.Instant.parse(
+                                        "2024-01-15T10:30:45.123456Z"))
+                    .execute();
+        }
+
+        @Test
+        public void timestampZeroMaps() throws Exception {
+            typeTest()
+                    .column("TIMESTAMP(0) NOT NULL",
+                            PrimitiveType.Datetime64)
+                        .value("'2024-01-15 10:30:45'",
+                                LocalDateTime.of(2024, 1, 15,
+                                        10, 30, 45))
+                    .execute();
+        }
+    }
+
+    @Nested class TypeTestsRow extends Db2TypeCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TypeTestsArrow extends Db2TypeCases {
+        @Override public boolean useArrow() { return true; }
+    }
+
+    abstract class Db2TableCases extends AbstractYdbImporterTableTest {
+
+        private static final int BIG_BLOB_SEED = 4000;
+        private static final int BIG_BLOB_SIZE = 512_000;
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(db2Container, SourceType.DB2, "IMPORT_TEST");
+        }
+
+        @Override
+        protected String smallBlob(byte[] data) {
+            return "BLOB(X'" + hex(data) + "')";
+        }
+
+        @Override
+        protected String bigBlob(String hexPair, int count) {
+            StringBuilder sb = new StringBuilder("BLOB(X'");
+            for (int i = 0; i < count; i++) {
+                sb.append(hexPair);
+            }
+            sb.append("')");
+            return sb.toString();
+        }
+
+        @Test
+        public void primaryKeySelection() throws Exception {
+            String s = schemaName();
+            importTogether()
+                    // 1. Composite PK
+                    .add(tableTest(s, "PK_COMPOSITE")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".PK_COMPOSITE ("
+                                + "REGION_ID INTEGER NOT NULL,"
+                                + "CITY_ID   INTEGER NOT NULL,"
+                                + "NAME      VARCHAR(100) NOT NULL,"
+                                + "PRIMARY KEY (REGION_ID, CITY_ID));"
+                                + "INSERT INTO " + s + ".PK_COMPOSITE VALUES"
+                                + "  (1, 10, 'Moscow');"
+                                + "INSERT INTO " + s + ".PK_COMPOSITE VALUES"
+                                + "  (1, 20, 'SPb');"
+                                + "INSERT INTO " + s + ".PK_COMPOSITE VALUES"
+                                + "  (2, 30, 'Berlin')")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".PK_COMPOSITE")
+                            .expectPrimaryKey("REGION_ID", "CITY_ID")
+                            .expectRowCount(3)
+                            .expectRowExists(
+                                    "REGION_ID", 1, "CITY_ID", 10,
+                                    "NAME", "Moscow"))
+                    // 2. PK preferred over UNIQUE constraint
+                    .add(tableTest(s, "PK_OVER_UNIQUE")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".PK_OVER_UNIQUE ("
+                                + "ID   BIGINT NOT NULL PRIMARY KEY,"
+                                + "CODE VARCHAR(20) NOT NULL,"
+                                + "VAL  INTEGER,"
+                                + "CONSTRAINT UQ_CODE UNIQUE (CODE));"
+                                + "INSERT INTO " + s + ".PK_OVER_UNIQUE VALUES"
+                                + "  (1, 'A', 10);"
+                                + "INSERT INTO " + s + ".PK_OVER_UNIQUE VALUES"
+                                + "  (2, 'B', 20)")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".PK_OVER_UNIQUE")
+                            .expectPrimaryKey("ID")
+                            .expectRowCount(2)
+                            .expectRowExists("ID", 1L, "CODE", "A"))
+                    // 3. UNIQUE constraint: fewer columns wins
+                    .add(tableTest(s, "UQ_FEWER_COLS")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".UQ_FEWER_COLS ("
+                                + "A BIGINT NOT NULL,"
+                                + "B VARCHAR(10) NOT NULL,"
+                                + "C VARCHAR(10) NOT NULL,"
+                                + "CONSTRAINT UQ_C UNIQUE (C),"
+                                + "CONSTRAINT UQ_AB UNIQUE (A, B));"
+                                + "INSERT INTO " + s + ".UQ_FEWER_COLS VALUES"
+                                + "  (1, 'x', 'p');"
+                                + "INSERT INTO " + s + ".UQ_FEWER_COLS VALUES"
+                                + "  (2, 'y', 'q')")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".UQ_FEWER_COLS")
+                            .expectPrimaryKey("C")
+                            .expectRowCount(2)
+                            .expectRowExists("C", "p"))
+                    // 4. Bare CREATE UNIQUE INDEX (no constraint)
+                    .add(tableTest(s, "UQ_INDEX_ONLY")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".UQ_INDEX_ONLY ("
+                                + "X BIGINT NOT NULL,"
+                                + "A VARCHAR(10) NOT NULL,"
+                                + "B VARCHAR(10) NOT NULL);"
+                                + "CREATE UNIQUE INDEX " + s
+                                + ".IDX_AB ON " + s + ".UQ_INDEX_ONLY (A, B);"
+                                + "INSERT INTO " + s + ".UQ_INDEX_ONLY VALUES"
+                                + "  (1, 'v1', 'v2');"
+                                + "INSERT INTO " + s + ".UQ_INDEX_ONLY VALUES"
+                                + "  (2, 'v4', 'v5')")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".UQ_INDEX_ONLY")
+                            .expectPrimaryKey("A", "B")
+                            .expectRowCount(2)
+                            .expectRowExists("A", "v1", "B", "v2"))
+                    .run();
+        }
+
+        @Test
+        public void partitionedImport() throws Exception {
+            String s = schemaName();
+            tableTest(s, "PART_SALES")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".PART_SALES ("
+                        + "SALE_ID   INTEGER NOT NULL,"
+                        + "REGION_ID INTEGER NOT NULL,"
+                        + "AMOUNT    INTEGER NOT NULL,"
+                        + "PRIMARY KEY (SALE_ID, REGION_ID)"
+                        + ") PARTITION BY RANGE (SALE_ID) ("
+                        + "  STARTING FROM (1) ENDING AT (2) INCLUSIVE,"
+                        + "  STARTING FROM (3) ENDING AT (4) INCLUSIVE,"
+                        + "  STARTING FROM (5) ENDING AT (6) INCLUSIVE,"
+                        + "  STARTING FROM (7) ENDING AT (8) INCLUSIVE);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (1, 10, 100);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (2, 20, 200);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (3, 30, 300);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (4, 40, 400);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (5, 50, 500);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (6, 60, 600);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (7, 70, 700);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (8, 80, 800)")
+                    .cleanupSql(
+                        "DROP TABLE " + s + ".PART_SALES")
+                    .expectPrimaryKey("SALE_ID", "REGION_ID")
+                    .expectRowCount(8)
+                    .expectRowExists("SALE_ID", 1, "AMOUNT", 100)
+                    .expectRowExists("SALE_ID", 8, "AMOUNT", 800)
+                    .run();
+        }
+
+        @Test
+        public void emptyTableCreatesSchema() throws Exception {
+            String s = schemaName();
+            tableTest(s, "EMPTY_TBL")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".EMPTY_TBL ("
+                        + "ID   INTEGER NOT NULL,"
+                        + "NAME VARCHAR(50) NOT NULL,"
+                        + "PRIMARY KEY (ID))")
+                    .cleanupSql("DROP TABLE " + s + ".EMPTY_TBL")
+                    .expectPrimaryKey("ID")
+                    .expectRowCount(0)
+                    .run();
+        }
+
+        @Test
+        public void customQueryTextImport() throws Exception {
+            String s = schemaName();
+            tableTest(s, "QUERY_SRC")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".QUERY_SRC ("
+                        + "ID  INTEGER NOT NULL,"
+                        + "VAL VARCHAR(50) NOT NULL,"
+                        + "PRIMARY KEY (ID));"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (1, 'a');"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (2, 'b');"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (3, 'c');"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (4, 'd')")
+                    .cleanupSql("DROP TABLE " + s + ".QUERY_SRC")
+                    .queryText("SELECT ID, VAL FROM " + s + ".QUERY_SRC"
+                            + " WHERE ID <= 2")
+                    .expectSyntheticKey()
+                    .expectRowCount(2)
+                    .expectRowExists("ID", 1, "VAL", "a")
+                    .expectRowExists("ID", 2, "VAL", "b")
+                    .run();
+        }
+
+        @Test
+        public void syntheticKeyDistinguishesRows() throws Exception {
+            String s = schemaName();
+            tableTest(s, "SYNTH_TBL")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".SYNTH_TBL ("
+                        + "SEQ  INTEGER NOT NULL,"
+                        + "NAME VARCHAR(50) NOT NULL);"
+                        + "INSERT INTO " + s + ".SYNTH_TBL VALUES (1, 'same');"
+                        + "INSERT INTO " + s + ".SYNTH_TBL VALUES (2, 'same');"
+                        + "INSERT INTO " + s + ".SYNTH_TBL VALUES (3, 'same')")
+                    .cleanupSql("DROP TABLE " + s + ".SYNTH_TBL")
+                    .expectSyntheticKey()
+                    .expectRowCount(3)
+                    .expectRowExists("SEQ", 1, "NAME", "same")
+                    .expectRowExists("SEQ", 2, "NAME", "same")
+                    .expectRowExists("SEQ", 3, "NAME", "same")
+                    .run();
+        }
+
+        @Test
+        public void skipUnsupportedColumns() throws Exception {
+            String s = schemaName();
+            tableTest(s, "SKIP_DB2")
+                    
+                    .withOptions(opts -> opts.setSkipUnknownTypes(true))
+                    .setupSql(
+                        "CREATE TABLE " + s + ".SKIP_DB2 ("
+                        + "ID     INTEGER NOT NULL,"
+                        + "NAME   VARCHAR(50) NOT NULL,"
+                        + "DFL16  DECFLOAT(16),"
+                        + "DFL34  DECFLOAT(34),"
+                        + "PRIMARY KEY (ID));"
+                        + "INSERT INTO " + s + ".SKIP_DB2"
+                        + " VALUES (1, 'a', 1.5, 2.5);"
+                        + "INSERT INTO " + s + ".SKIP_DB2"
+                        + " VALUES (2, 'b', 3.5, 4.5)")
+                    .cleanupSql("DROP TABLE " + s + ".SKIP_DB2")
+                    .expectPrimaryKey("ID")
+                    .expectSkippedColumns("DFL16", "DFL34")
+                    .expectRowCount(2)
+                    .expectRowExists("ID", 1, "NAME", "a")
+                    .run();
+        }
+
+        @Test
+        public void partitionedMultiBlobSynthKey() throws Exception {
+            String s = schemaName();
+
+            byte[] thumbEU1 = "thumb-eu-1".getBytes();
+            byte[] thumbEU2 = "thumb-eu-2".getBytes();
+            byte[] thumbUS1 = "thumb-us-1".getBytes();
+            byte[] thumbUS2 = "thumb-us-2".getBytes();
+
+            byte[] fullEU1 = filled(BIG_BLOB_SIZE, (byte) 0x11);
+            byte[] fullEU2 = filled(BIG_BLOB_SIZE, (byte) 0x22);
+            byte[] fullUS1 = filled(BIG_BLOB_SIZE, (byte) 0x33);
+            byte[] fullUS2 = filled(BIG_BLOB_SIZE, (byte) 0x44);
+
+            StringBuilder setup = new StringBuilder();
+            setup.append("CREATE TABLE ").append(s).append(".MEGA_BLOB (")
+                    .append("REGION    VARCHAR(10) NOT NULL,")
+                    .append("LABEL     VARCHAR(30),")
+                    .append("THUMBNAIL BLOB,")
+                    .append("FULLSIZE  BLOB")
+                    .append(") PARTITION BY RANGE (REGION) (")
+                    .append("STARTING FROM ('EU') ENDING AT ('EU') INCLUSIVE,")
+                    .append("STARTING FROM ('US') ENDING AT ('US') INCLUSIVE)");
+            appendMegaBlobInsert(setup, s, "EU", "eu-book-1", thumbEU1, "11");
+            appendMegaBlobInsert(setup, s, "EU", "eu-book-2", thumbEU2, "22");
+            setup.append(";INSERT INTO ").append(s).append(".MEGA_BLOB")
+                    .append(" VALUES ('EU', 'eu-null', NULL, NULL)");
+            appendMegaBlobInsert(setup, s, "US", "us-book-1", thumbUS1, "33");
+            appendMegaBlobInsert(setup, s, "US", "us-book-2", thumbUS2, "44");
+            for (int i = 0; i < 7; i++) {
+                setup.append(";UPDATE ").append(s).append(".MEGA_BLOB")
+                        .append(" SET FULLSIZE = FULLSIZE || FULLSIZE")
+                        .append(" WHERE FULLSIZE IS NOT NULL");
+            }
+
+            tableTest(s, "MEGA_BLOB")
+                    
+                    .setupSql(setup.toString())
+                    .cleanupSql("DROP TABLE " + s + ".MEGA_BLOB")
+                    .expectSyntheticKey()
+                    .expectRowCount(5)
+                    .expectBlobColumn("THUMBNAIL")
+                    .expectBlobColumn("FULLSIZE")
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "eu-book-1", thumbEU1)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "eu-book-2", thumbEU2)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "eu-null", null)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "us-book-1", thumbUS1)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "us-book-2", thumbUS2)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "eu-book-1", fullEU1)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "eu-book-2", fullEU2)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "eu-null", null)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "us-book-1", fullUS1)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "us-book-2", fullUS2)
+                    .run();
+
+            tableTest(s, "SMALL_BLOB")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".SMALL_BLOB ("
+                        + "ID   INTEGER NOT NULL PRIMARY KEY,"
+                        + "NAME VARCHAR(50) NOT NULL,"
+                        + "DATA BLOB);"
+                        + "INSERT INTO " + s + ".SMALL_BLOB VALUES"
+                        + "  (1, 'hello',     " + smallBlob("Hello".getBytes()) + ");"
+                        + "INSERT INTO " + s + ".SMALL_BLOB VALUES"
+                        + "  (2, 'null_blob', NULL);"
+                        + "INSERT INTO " + s + ".SMALL_BLOB VALUES"
+                        + "  (3, 'world',     " + smallBlob("World".getBytes()) + ")")
+                    .cleanupSql("DROP TABLE " + s + ".SMALL_BLOB")
+                    .expectPrimaryKey("ID")
+                    .expectRowCount(3)
+                    .expectBlobColumn("DATA")
+                    .expectBlobBytes("DATA", "ID", 1, "Hello".getBytes())
+                    .expectBlobBytes("DATA", "ID", 3, "World".getBytes())
+                    .expectBlobBytes("DATA", "ID", 2, null)
+                    .run();
+        }
+
+        private void appendMegaBlobInsert(StringBuilder sb, String schema,
+                String region, String label, byte[] thumb, String hexPair) {
+            byte[] seed = filled(BIG_BLOB_SEED, (byte) Integer.parseInt(hexPair, 16));
+            sb.append(";INSERT INTO ").append(schema).append(".MEGA_BLOB VALUES ('")
+                    .append(region).append("', '").append(label).append("', ")
+                    .append(smallBlob(thumb)).append(", ")
+                    .append("BLOB(X'").append(hex(seed)).append("'))");
+        }
+
+        @Test
+        public void clobContentImport() throws Exception {
+            String s = schemaName();
+            int size = 524288;
+            String big = repeat("Z", size);
+            tableTest(s, "CLOB_TBL")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".CLOB_TBL ("
+                        + "ID   INTEGER NOT NULL PRIMARY KEY,"
+                        + "NOTE CLOB);"
+                        + "INSERT INTO " + s + ".CLOB_TBL VALUES (2, NULL);"
+                        + "INSERT INTO " + s + ".CLOB_TBL VALUES (3, '')")
+                    .insertRow("INSERT INTO " + s + ".CLOB_TBL VALUES (?, ?)",
+                            1, big)
+                    .cleanupSql("DROP TABLE " + s + ".CLOB_TBL")
+                    .expectPrimaryKey("ID")
+                    .expectRowCount(3)
+                    .expectClobColumn("NOTE")
+                    .expectClobContent("NOTE", "ID", 1, big)
+                    .expectClobContent("NOTE", "ID", 2, null)
+                    .expectClobContent("NOTE", "ID", 3, "")
+                    .run();
+        }
+    }
+
+    @Nested class TableTestsRow extends Db2TableCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TableTestsArrow extends Db2TableCases {
+        @Override public boolean useArrow() { return true; }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/greenplum/GreenplumTestContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/greenplum/GreenplumTestContainer.java
@@ -1,0 +1,50 @@
+package tech.ydb.importer.integration.sources.greenplum;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public final class GreenplumTestContainer
+        extends JdbcDatabaseContainer<GreenplumTestContainer> {
+
+    public static final String DEFAULT_IMAGE = "woblerr/greenplum:7.1.0";
+
+    private static final int GP_PORT = 5432;
+
+    public GreenplumTestContainer() {
+        this(DEFAULT_IMAGE);
+    }
+
+    public GreenplumTestContainer(String imageName) {
+        super(DockerImageName.parse(imageName));
+        addExposedPort(GP_PORT);
+        withEnv("GREENPLUM_PASSWORD", "test");
+        withStartupTimeoutSeconds(300);
+        withConnectTimeoutSeconds(120);
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "org.postgresql.Driver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:postgresql://" + getHost() + ":"
+                + getMappedPort(GP_PORT) + "/demo";
+    }
+
+    @Override
+    public String getUsername() {
+        return "gpadmin";
+    }
+
+    @Override
+    public String getPassword() {
+        return "test";
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1";
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/greenplum/GreenplumYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/greenplum/GreenplumYdbImporterTest.java
@@ -1,0 +1,229 @@
+package tech.ydb.importer.integration.sources.greenplum;
+
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.integration.sources.postgres.AbstractPostgresCompatibleTableCases;
+import tech.ydb.importer.integration.sources.postgres.AbstractPostgresCompatibleTypeCases;
+
+/** Greenplum integration tests. */
+public class GreenplumYdbImporterTest {
+
+    private static GreenplumTestContainer gpContainer;
+    private static TimeZone originalTz;
+
+    @BeforeAll
+    static void startGreenplum() {
+        originalTz = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        gpContainer = new GreenplumTestContainer();
+        gpContainer.start();
+    }
+
+    @AfterAll
+    static void stopGreenplum() {
+        if (gpContainer != null) {
+            gpContainer.stop();
+            gpContainer = null;
+        }
+        if (originalTz != null) {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+
+    abstract class GreenplumTypeCases
+            extends AbstractPostgresCompatibleTypeCases {
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(gpContainer, SourceType.GREENPLUM, "public");
+        }
+    }
+
+    @Nested class TypeTestsRow extends GreenplumTypeCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TypeTestsArrow extends GreenplumTypeCases {
+        @Override public boolean useArrow() { return true; }
+    }
+
+    abstract class GreenplumTableCases
+            extends AbstractPostgresCompatibleTableCases {
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(gpContainer, SourceType.GREENPLUM, "public");
+        }
+
+        @Test
+        @Override
+        @Disabled("GP Large Objects (OID) not supported")
+        public void partitionedMultiBlobSynthKey() throws Exception {
+        }
+
+        /**
+         * GP requires every UNIQUE/PK to include the distribution column.
+         * pk_over_unique uses a composite PK, uq_fewer_cols includes it explicitly.
+         */
+        @Test
+        @Override
+        public void primaryKeySelection() throws Exception {
+            String s = schemaName();
+            importTogether()
+                    
+                    .add(tableTest(s, "pk_composite")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".pk_composite ("
+                                + "  region_id INTEGER NOT NULL,"
+                                + "  city_id   INTEGER NOT NULL,"
+                                + "  name      VARCHAR(100) NOT NULL,"
+                                + "  PRIMARY KEY (region_id, city_id)"
+                                + ");"
+                                + "INSERT INTO " + s + ".pk_composite VALUES"
+                                + "  (1, 10, 'Moscow'),"
+                                + "  (1, 20, 'SPb'),"
+                                + "  (2, 30, 'Berlin')")
+                            .cleanupSql(
+                                "DROP TABLE IF EXISTS "
+                                + s + ".pk_composite CASCADE")
+                            .expectPrimaryKey("region_id", "city_id")
+                            .expectRowCount(3)
+                            .expectRowExists(
+                                    "region_id", 1, "city_id", 10,
+                                    "name", "Moscow"))
+                    .add(tableTest(s, "pk_over_unique")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".pk_over_unique ("
+                                + "  id   BIGINT NOT NULL,"
+                                + "  code VARCHAR(20) NOT NULL,"
+                                + "  val  INTEGER,"
+                                + "  PRIMARY KEY (id, code),"
+                                + "  UNIQUE (code)"
+                                + ");"
+                                + "INSERT INTO " + s + ".pk_over_unique VALUES"
+                                + "  (1, 'A', 10),"
+                                + "  (2, 'B', 20)")
+                            .cleanupSql(
+                                "DROP TABLE IF EXISTS "
+                                + s + ".pk_over_unique CASCADE")
+                            .expectPrimaryKey("id", "code")
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1L, "code", "A"))
+                    .add(tableTest(s, "uq_fewer_cols")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".uq_fewer_cols ("
+                                + "  a BIGINT NOT NULL,"
+                                + "  b VARCHAR(10) NOT NULL,"
+                                + "  c VARCHAR(10) NOT NULL UNIQUE,"
+                                + "  UNIQUE (a, c)"
+                                + ");"
+                                + "INSERT INTO " + s + ".uq_fewer_cols VALUES"
+                                + "  (1, 'x', 'p'),"
+                                + "  (2, 'y', 'q')")
+                            .cleanupSql(
+                                "DROP TABLE IF EXISTS "
+                                + s + ".uq_fewer_cols CASCADE")
+                            .expectPrimaryKey("c")
+                            .expectRowCount(2)
+                            .expectRowExists("c", "p"))
+                    .add(tableTest(s, "uq_sorted_names")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".uq_sorted_names ("
+                                + "  x BIGINT NOT NULL,"
+                                + "  a VARCHAR(10) NOT NULL,"
+                                + "  b VARCHAR(10) NOT NULL,"
+                                + "  z VARCHAR(10) NOT NULL,"
+                                + "  UNIQUE (z, a),"
+                                + "  UNIQUE (a, b)"
+                                + ");"
+                                + "INSERT INTO " + s + ".uq_sorted_names VALUES"
+                                + "  (1, 'v1', 'v2', 'v3'),"
+                                + "  (2, 'v4', 'v5', 'v6')")
+                            .cleanupSql(
+                                "DROP TABLE IF EXISTS "
+                                + s + ".uq_sorted_names CASCADE")
+                            .expectPrimaryKey("a", "b")
+                            .expectRowCount(2)
+                            .expectRowExists("a", "v1", "b", "v2"))
+                    .run();
+        }
+
+        @Test
+        @Override
+        public void skipUnsupportedColumns() throws Exception {
+            String s = schemaName();
+            tableTest(s, "skip_pg")
+                    
+                    .withOptions(opts -> opts.setSkipUnknownTypes(true))
+                    .setupSql(
+                        "CREATE TABLE " + s + ".skip_pg ("
+                        + "  id   INTEGER PRIMARY KEY,"
+                        + "  name VARCHAR(50) NOT NULL,"
+                        + "  uid  UUID,"
+                        + "  doc  JSONB,"
+                        + "  tags INTEGER[]"
+                        + ");"
+                        + "INSERT INTO " + s + ".skip_pg"
+                        + "  (id, name, uid, doc, tags) VALUES"
+                        + "  (1, 'a',"
+                        + "   '11111111-1111-1111-1111-111111111111'::uuid,"
+                        + "   '{\"k\":1}', ARRAY[1,2]),"
+                        + "  (2, 'b',"
+                        + "   '22222222-2222-2222-2222-222222222222'::uuid,"
+                        + "   '{\"k\":2}', ARRAY[3,4])")
+                    .cleanupSql(
+                        "DROP TABLE IF EXISTS "
+                        + s + ".skip_pg CASCADE")
+                    .expectPrimaryKey("id")
+                    .expectSkippedColumns("uid", "doc", "tags")
+                    .expectRowCount(2)
+                    .expectRowExists("id", 1, "name", "a")
+                    .expectRowExists("id", 2, "name", "b")
+                    .run();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"row", "column"})
+        public void importFromAoTable(String orientation) throws Exception {
+            String s = schemaName();
+            String tableName = "gp_ao_" + orientation;
+            tableTest(s, tableName)
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + "." + tableName + " ("
+                        + "  id INTEGER NOT NULL PRIMARY KEY,"
+                        + "  name VARCHAR(50) NOT NULL,"
+                        + "  amount INTEGER NOT NULL"
+                        + ") WITH (appendoptimized=true,"
+                        + " orientation=" + orientation + ","
+                        + " compresstype=zstd,"
+                        + " compresslevel=5);"
+                        + "INSERT INTO " + s + "." + tableName + " VALUES"
+                        + "  (1, 'alice', 100),"
+                        + "  (2, 'bob', 200),"
+                        + "  (3, 'carol', 300)")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + "." + tableName + " CASCADE")
+                    .expectPrimaryKey("id")
+                    .expectRowCount(3)
+                    .expectRowExists("id", 1, "name", "alice", "amount", 100)
+                    .expectRowExists("id", 3, "name", "carol", "amount", 300)
+                    .run();
+        }
+    }
+
+    @Nested class TableTestsRow extends GreenplumTableCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TableTestsArrow extends GreenplumTableCases {
+        @Override public boolean useArrow() { return true; }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaLoader.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaLoader.java
@@ -1,0 +1,89 @@
+package tech.ydb.importer.integration.sources.hana;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.EnumSet;
+import java.util.Set;
+
+import tech.ydb.importer.integration.verification.DialectLoader;
+import tech.ydb.importer.integration.verification.LogicalType;
+import tech.ydb.importer.integration.verification.TableScenario.PartitionStyle;
+import tech.ydb.importer.integration.verification.TableScenario;
+
+public final class HanaLoader extends DialectLoader {
+
+    public static final HanaLoader INSTANCE = new HanaLoader();
+
+    private HanaLoader() {
+    }
+
+    @Override
+    protected String toDdl(LogicalType type) {
+        switch (type) {
+            case INT32:           return "INTEGER";
+            case INT64:           return "BIGINT";
+            case DECIMAL_18_4:    return "DECIMAL(18, 4)";
+            case STRING:          return "NVARCHAR(255)";
+            case BOOL:            return "BOOLEAN";
+            case DATE:            return "DATE";
+            case DATETIME:        return "TIMESTAMP";
+            default:
+                throw new IllegalArgumentException("Unsupported: " + type);
+        }
+    }
+
+    @Override
+    protected String blobDdlType() {
+        return "BLOB";
+    }
+
+    @Override
+    public Set<PartitionStyle> supportedPartitions() {
+        return EnumSet.of(PartitionStyle.HASH_INT, PartitionStyle.RANGE_INT,
+                PartitionStyle.RANGE_DATE);
+    }
+
+    @Override
+    protected void appendPartition(StringBuilder ddl, PartitionStyle style,
+                                   String column, TableScenario scenario) {
+        switch (style) {
+            case HASH_INT:
+            case RANGE_INT:
+                ddl.append(" PARTITION BY HASH(").append(column)
+                        .append(") PARTITIONS ")
+                        .append(partitionCount(scenario));
+                break;
+            case RANGE_DATE:
+                ddl.append(" PARTITION BY RANGE(").append(column).append(")")
+                        .append(" (PARTITION '2025-01-01' <= VALUES < '2026-01-01',")
+                        .append(" PARTITION '2026-01-01' <= VALUES < '2027-01-01',")
+                        .append(" PARTITION OTHERS)");
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    protected String createTablePrefix() {
+        return "CREATE TABLE ";
+    }
+
+    @Override
+    public String adaptTableName(String name) {
+        return name.toUpperCase();
+    }
+
+    @Override
+    public void onConnectionOpened(Connection conn, String schema) throws SQLException {
+        try (Statement st = conn.createStatement()) {
+            st.execute("SET SCHEMA \"" + schema + "\"");
+        }
+    }
+
+    @Override
+    public boolean supportsMultiRowInsert() {
+        return false;
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaTestContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaTestContainer.java
@@ -1,0 +1,79 @@
+package tech.ydb.importer.integration.sources.hana;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public final class HanaTestContainer
+        extends JdbcDatabaseContainer<HanaTestContainer> {
+
+    public static final String DEFAULT_IMAGE =
+            "saplabs/hanaexpress:2.00.088.00.20251110.1";
+    public static final String SCHEMA = "IMPORT_TEST";
+
+    private static final int SYSTEMDB_PORT = 39013;
+    private static final int TENANT_PORT = 39041;
+    private static final String MASTER_PASSWORD = "HxeTest1";
+
+    public HanaTestContainer() {
+        this(DEFAULT_IMAGE);
+    }
+
+    public HanaTestContainer(String imageName) {
+        super(DockerImageName.parse(imageName));
+        addExposedPort(SYSTEMDB_PORT);
+        addExposedPort(TENANT_PORT);
+        withStartupTimeoutSeconds(900);
+        withConnectTimeoutSeconds(300);
+        withCommand(
+                "--agree-to-sap-license",
+                "--master-password", MASTER_PASSWORD);
+        // Mount /hana/mounts as tmpfs to speed up HANA startup.
+        withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()
+                .withTmpFs(Collections.singletonMap("/hana/mounts",
+                        "rw,exec,mode=0770,uid=12000,gid=79,size=32g")));
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "com.sap.db.jdbc.Driver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:sap://" + getHost() + ":" + getMappedPort(TENANT_PORT);
+    }
+
+    @Override
+    public String getUsername() {
+        return "SYSTEM";
+    }
+
+    @Override
+    public String getPassword() {
+        return MASTER_PASSWORD;
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1 FROM DUMMY";
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        try (Connection c = DriverManager.getConnection(
+                getJdbcUrl(), getUsername(), getPassword());
+             Statement st = c.createStatement()) {
+            st.execute("CREATE SCHEMA " + SCHEMA);
+        } catch (SQLException e) {
+            throw new RuntimeException(
+                    "Failed to create schema " + SCHEMA, e);
+        }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaTestContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaTestContainer.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Collections;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -33,10 +32,6 @@ public final class HanaTestContainer
         withCommand(
                 "--agree-to-sap-license",
                 "--master-password", MASTER_PASSWORD);
-        // Mount /hana/mounts as tmpfs to speed up HANA startup.
-        withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()
-                .withTmpFs(Collections.singletonMap("/hana/mounts",
-                        "rw,exec,mode=0770,uid=12000,gid=79,size=32g")));
     }
 
     @Override

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
@@ -60,6 +60,11 @@ public class HanaYdbImporterTest {
             return super.typeTest().withIdentifierQuote("\"");
         }
 
+        @Override
+        protected String dropTableSql(String qualifiedTable) {
+            return "DROP TABLE " + qualifiedTable + " CASCADE";
+        }
+
         @Test
         public void tinyintMapsToInt32() throws Exception {
             typeTest()

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
@@ -1,0 +1,634 @@
+package tech.ydb.importer.integration.sources.hana;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.config.TableOptions.DateConv;
+import tech.ydb.importer.integration.tabletest.AbstractYdbImporterTableTest;
+import tech.ydb.importer.integration.typetest.AbstractYdbImporterTypeTest;
+import tech.ydb.table.values.DecimalType;
+import tech.ydb.table.values.PrimitiveType;
+
+/** HANA integration tests. */
+public class HanaYdbImporterTest {
+
+    private static HanaTestContainer hanaContainer;
+    private static TimeZone originalTz;
+
+    @BeforeAll
+    static void startHana() {
+        originalTz = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        hanaContainer = new HanaTestContainer();
+        hanaContainer.start();
+    }
+
+    @AfterAll
+    static void stopHana() {
+        if (hanaContainer != null) {
+            hanaContainer.stop();
+            hanaContainer = null;
+        }
+        if (originalTz != null) {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+
+    abstract class HanaTypeCases extends AbstractYdbImporterTypeTest {
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(hanaContainer, SourceType.HANA, "IMPORT_TEST");
+        }
+
+        /**
+         * HANA folds unquoted identifiers to UPPERCASE. Importer queries them quoted,
+         * so test DDL must also quote them to preserve case.
+         */
+        @Override
+        protected tech.ydb.importer.integration.typetest.TypeTestBuilder typeTest() {
+            return super.typeTest().withIdentifierQuote("\"");
+        }
+
+        @Test
+        public void tinyintMapsToInt32() throws Exception {
+            typeTest()
+                    .column("TINYINT NOT NULL", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("255", 255)
+                    .column("TINYINT", PrimitiveType.Int32.makeOptional())
+                        .value("42", 42)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void smallintMapsToInt32() throws Exception {
+            typeTest()
+                    .column("SMALLINT NOT NULL", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("32767", 32767)
+                        .value("-32768", -32768)
+                    .execute();
+        }
+
+        @Test
+        public void integerBoundaries() throws Exception {
+            typeTest()
+                    .column("INTEGER NOT NULL", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("2147483647", Integer.MAX_VALUE)
+                        .value("-2147483648", Integer.MIN_VALUE)
+                    .column("INTEGER", PrimitiveType.Int32.makeOptional())
+                        .value("42", 42)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void bigintBoundaries() throws Exception {
+            typeTest()
+                    .column("BIGINT NOT NULL", PrimitiveType.Int64)
+                        .value("0", 0L)
+                        .value("9223372036854775807", Long.MAX_VALUE)
+                        .value("-9223372036854775808", Long.MIN_VALUE)
+                    .execute();
+        }
+
+        @Test
+        public void doublePrecision() throws Exception {
+            typeTest()
+                    .column("DOUBLE NOT NULL", PrimitiveType.Double)
+                        .value("1.5", 1.5d)
+                        .value("1e100", 1e100d)
+                    .column("DOUBLE", PrimitiveType.Double.makeOptional())
+                        .value("9.99", 9.99d)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void realMapsToFloat() throws Exception {
+            typeTest()
+                    .column("REAL NOT NULL", PrimitiveType.Float)
+                        .value("1.5", 1.5f)
+                        .value("-0.25", -0.25f)
+                    .column("REAL", PrimitiveType.Float.makeOptional())
+                        .value("3.14", 3.14f)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void decimalWithScale() throws Exception {
+            typeTest()
+                    .column("DECIMAL(10, 4) NOT NULL",
+                            DecimalType.of(10, 4))
+                        .value("123.4567", new BigDecimal("123.4567"))
+                        .value("-999999.9999",
+                                new BigDecimal("-999999.9999"))
+                    .column("DECIMAL(10, 2)",
+                            DecimalType.of(10, 2).makeOptional())
+                        .value("99.99", new BigDecimal("99.99"))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void decimalZeroScaleToInt32() throws Exception {
+            typeTest()
+                    .column("DECIMAL(5, 0) NOT NULL", PrimitiveType.Int32)
+                        .value("12345", 12345)
+                        .value("-99999", -99999)
+                    .execute();
+        }
+
+        @Test
+        public void decimalHighPrecisionToDecimal() throws Exception {
+            typeTest()
+                    .column("DECIMAL(25, 0) NOT NULL",
+                            DecimalType.of(35, 0))
+                        .value("1234567890123456789012345",
+                                new BigDecimal(
+                                        "1234567890123456789012345"))
+                    .execute();
+        }
+
+        @Test
+        public void smallDecimalMaps() throws Exception {
+            // HANA SMALLDECIMAL reports as DECIMAL(16,0). Importer rule
+            // scale=0 + precision in 10-19 picks Int64.
+            typeTest()
+                    .column("SMALLDECIMAL NOT NULL", PrimitiveType.Int64)
+                        .value("12345", 12345L)
+                        .value("-67890", -67890L)
+                    .execute();
+        }
+
+        @Test
+        public void nvarcharUnicode() throws Exception {
+            typeTest()
+                    .column("NVARCHAR(100) NOT NULL", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("''", "")
+                        .value("'кириллица'", "кириллица")
+                        .value("'emoji \uD83D\uDE00'", "emoji \uD83D\uDE00")
+                    .column("NVARCHAR(100)",
+                            PrimitiveType.Text.makeOptional())
+                        .value("'hello'", "hello")
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void varcharAsciiMaps() throws Exception {
+            typeTest()
+                    .column("VARCHAR(100) NOT NULL", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("''", "")
+                    .execute();
+        }
+
+        @Test
+        public void alphanumMaps() throws Exception {
+            typeTest()
+                    .column("ALPHANUM(20) NOT NULL", PrimitiveType.Text)
+                        .value("'ABC123'", "ABC123")
+                        .value("'XYZ'", "XYZ")
+                    .execute();
+        }
+
+        @Test
+        public void varbinaryMapsToBytes() throws Exception {
+            typeTest()
+                    .column("VARBINARY(100) NOT NULL", PrimitiveType.Bytes)
+                        .value("x'DEADBEEF'",
+                                new byte[]{(byte) 0xDE, (byte) 0xAD,
+                                           (byte) 0xBE, (byte) 0xEF})
+                        .value("x'00'", new byte[]{(byte) 0x00})
+                    .execute();
+        }
+
+        @Test
+        public void booleanMaps() throws Exception {
+            typeTest()
+                    .column("BOOLEAN NOT NULL", PrimitiveType.Bool)
+                        .value("TRUE", true)
+                        .value("FALSE", false)
+                    .column("BOOLEAN", PrimitiveType.Bool.makeOptional())
+                        .value("TRUE", true)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void dateMaps() throws Exception {
+            typeTest()
+                    .column("DATE NOT NULL", PrimitiveType.Date32)
+                        .value("'1970-01-01'",
+                                LocalDate.of(1970, 1, 1))
+                        .value("'2024-01-15'",
+                                LocalDate.of(2024, 1, 15))
+                    .column("DATE", PrimitiveType.Date32.makeOptional())
+                        .value("'2024-01-15'",
+                                LocalDate.of(2024, 1, 15))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void dateAsInt() throws Exception {
+            typeTest()
+                    .withOptions(
+                            opts -> opts.setDateConv(DateConv.INT))
+                    .column("DATE NOT NULL", PrimitiveType.Int32)
+                        .value("'1970-01-01'", 19700101)
+                        .value("'2024-01-15'", 20240115)
+                    .execute();
+        }
+
+        @Test
+        public void dateAsText() throws Exception {
+            typeTest()
+                    .withOptions(
+                            opts -> opts.setDateConv(DateConv.STR))
+                    .column("DATE NOT NULL", PrimitiveType.Text)
+                        .value("'1970-01-01'", "1970/01/01")
+                        .value("'2024-01-15'", "2024/01/15")
+                    .execute();
+        }
+
+        @Test
+        public void timeMapsToInt32() throws Exception {
+            typeTest()
+                    .column("TIME NOT NULL", PrimitiveType.Int32)
+                        .value("'00:00:00'", 0)
+                        .value("'10:30:45'", 37845)
+                        .value("'23:59:59'", 86399)
+                    .execute();
+        }
+
+        @Test
+        public void seconddateMaps() throws Exception {
+            // SECONDDATE has second precision. Driver reports scale=0.
+            // YDB SDK returns Datetime64 as LocalDateTime.
+            typeTest()
+                    .column("SECONDDATE NOT NULL",
+                            PrimitiveType.Datetime64)
+                        .value("'2024-01-15 10:30:45'",
+                                java.time.LocalDateTime.of(
+                                        2024, 1, 15, 10, 30, 45))
+                    .execute();
+        }
+
+        @Test
+        public void timestampMaps() throws Exception {
+            // HANA TIMESTAMP has 100ns precision (scale=7). YDB Timestamp64 is microseconds,
+            // so values round down at the us boundary.
+            typeTest()
+                    .column("TIMESTAMP NOT NULL", PrimitiveType.Timestamp64)
+                        .value("'2024-01-15 10:30:45'",
+                                Instant.parse(
+                                        "2024-01-15T10:30:45Z"))
+                        .value("'2024-01-15 10:30:45.123456'",
+                                Instant.parse(
+                                    "2024-01-15T10:30:45.123456Z"))
+                    .execute();
+        }
+    }
+
+    @Nested class TypeTestsRow extends HanaTypeCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TypeTestsArrow extends HanaTypeCases {
+        @Override public boolean useArrow() { return true; }
+    }
+
+    abstract class HanaTableCases extends AbstractYdbImporterTableTest {
+
+        private static final int BIG_BLOB_SIZE = 524_288;
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(hanaContainer, SourceType.HANA, "IMPORT_TEST");
+        }
+
+        @Override
+        protected String smallBlob(byte[] data) {
+            return "TO_BLOB(HEXTOBIN('" + hex(data) + "'))";
+        }
+
+        @Test
+        public void primaryKeySelection() throws Exception {
+            String s = schemaName();
+            importTogether()
+                    
+                    .add(tableTest(s, "PK_COMPOSITE")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".PK_COMPOSITE ("
+                                + "REGION_ID INTEGER NOT NULL,"
+                                + "CITY_ID   INTEGER NOT NULL,"
+                                + "NAME      NVARCHAR(100) NOT NULL,"
+                                + "PRIMARY KEY (REGION_ID, CITY_ID));"
+                                + "INSERT INTO " + s + ".PK_COMPOSITE VALUES"
+                                + "  (1, 10, 'Moscow');"
+                                + "INSERT INTO " + s + ".PK_COMPOSITE VALUES"
+                                + "  (1, 20, 'SPb');"
+                                + "INSERT INTO " + s + ".PK_COMPOSITE VALUES"
+                                + "  (2, 30, 'Berlin')")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".PK_COMPOSITE CASCADE")
+                            .expectPrimaryKey("REGION_ID", "CITY_ID")
+                            .expectRowCount(3)
+                            .expectRowExists(
+                                    "REGION_ID", 1, "CITY_ID", 10,
+                                    "NAME", "Moscow"))
+                    .add(tableTest(s, "PK_OVER_UNIQUE")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".PK_OVER_UNIQUE ("
+                                + "ID   BIGINT NOT NULL PRIMARY KEY,"
+                                + "CODE NVARCHAR(20) NOT NULL,"
+                                + "VAL  INTEGER,"
+                                + "CONSTRAINT UQ_CODE UNIQUE (CODE));"
+                                + "INSERT INTO " + s + ".PK_OVER_UNIQUE VALUES"
+                                + "  (1, 'A', 10);"
+                                + "INSERT INTO " + s + ".PK_OVER_UNIQUE VALUES"
+                                + "  (2, 'B', 20)")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".PK_OVER_UNIQUE CASCADE")
+                            .expectPrimaryKey("ID")
+                            .expectRowCount(2)
+                            .expectRowExists("ID", 1L, "CODE", "A"))
+                    .add(tableTest(s, "UQ_FEWER_COLS")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".UQ_FEWER_COLS ("
+                                + "A BIGINT NOT NULL,"
+                                + "B NVARCHAR(10) NOT NULL,"
+                                + "C NVARCHAR(10) NOT NULL,"
+                                + "CONSTRAINT UQ_C UNIQUE (C),"
+                                + "CONSTRAINT UQ_AB UNIQUE (A, B));"
+                                + "INSERT INTO " + s + ".UQ_FEWER_COLS VALUES"
+                                + "  (1, 'x', 'p');"
+                                + "INSERT INTO " + s + ".UQ_FEWER_COLS VALUES"
+                                + "  (2, 'y', 'q')")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".UQ_FEWER_COLS CASCADE")
+                            .expectPrimaryKey("C")
+                            .expectRowCount(2)
+                            .expectRowExists("C", "p"))
+                    .add(tableTest(s, "UQ_SORTED_NAMES")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".UQ_SORTED_NAMES ("
+                                + "X BIGINT NOT NULL,"
+                                + "A NVARCHAR(10) NOT NULL,"
+                                + "B NVARCHAR(10) NOT NULL,"
+                                + "Z NVARCHAR(10) NOT NULL,"
+                                + "CONSTRAINT UQ_S_ZA UNIQUE (Z, A),"
+                                + "CONSTRAINT UQ_S_AB UNIQUE (A, B));"
+                                + "INSERT INTO " + s + ".UQ_SORTED_NAMES VALUES"
+                                + "  (1, 'v1', 'v2', 'v3');"
+                                + "INSERT INTO " + s + ".UQ_SORTED_NAMES VALUES"
+                                + "  (2, 'v4', 'v5', 'v6')")
+                            .cleanupSql(
+                                "DROP TABLE " + s + ".UQ_SORTED_NAMES CASCADE")
+                            .expectPrimaryKey("A", "B")
+                            .expectRowCount(2)
+                            .expectRowExists("A", "v1", "B", "v2"))
+                    .run();
+        }
+
+        @Test
+        public void partitionedImport() throws Exception {
+            String s = schemaName();
+            tableTest(s, "PART_SALES")
+                    
+                    .setupSql(
+                        "CREATE COLUMN TABLE " + s + ".PART_SALES ("
+                        + "SALE_ID   INTEGER NOT NULL,"
+                        + "REGION_ID INTEGER NOT NULL,"
+                        + "AMOUNT    INTEGER NOT NULL,"
+                        + "PRIMARY KEY (SALE_ID, REGION_ID)"
+                        + ") PARTITION BY HASH (SALE_ID) PARTITIONS 4;"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (1, 10, 100);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (2, 20, 200);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (3, 30, 300);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (4, 40, 400);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (5, 50, 500);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (6, 60, 600);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (7, 70, 700);"
+                        + "INSERT INTO " + s + ".PART_SALES VALUES (8, 80, 800)")
+                    .cleanupSql(
+                        "DROP TABLE " + s + ".PART_SALES CASCADE")
+                    .expectPrimaryKey("SALE_ID", "REGION_ID")
+                    .expectRowCount(8)
+                    .expectRowExists("SALE_ID", 1, "AMOUNT", 100)
+                    .expectRowExists("SALE_ID", 8, "AMOUNT", 800)
+                    .run();
+        }
+
+        @Test
+        public void partitionedMultiBlobSynthKey() throws Exception {
+            String s = schemaName();
+
+            byte[] thumbEU1 = "thumb-eu-1".getBytes();
+            byte[] thumbEU2 = "thumb-eu-2".getBytes();
+            byte[] thumbUS1 = "thumb-us-1".getBytes();
+            byte[] thumbUS2 = "thumb-us-2".getBytes();
+
+            byte[] fullEU1 = filled(BIG_BLOB_SIZE, (byte) 0x11);
+            byte[] fullEU2 = filled(BIG_BLOB_SIZE, (byte) 0x22);
+            byte[] fullUS1 = filled(BIG_BLOB_SIZE, (byte) 0x33);
+            byte[] fullUS2 = filled(BIG_BLOB_SIZE, (byte) 0x44);
+
+            String insertSql = "INSERT INTO " + s + ".MEGA_BLOB"
+                    + " VALUES (?, ?, ?, ?)";
+            tableTest(s, "MEGA_BLOB")
+                    
+                    .setupSql(
+                        "CREATE COLUMN TABLE " + s + ".MEGA_BLOB ("
+                        + "REGION    NVARCHAR(10) NOT NULL,"
+                        + "LABEL     NVARCHAR(30),"
+                        + "THUMBNAIL BLOB,"
+                        + "FULLSIZE  BLOB"
+                        + ") PARTITION BY RANGE (REGION) ("
+                        + "  PARTITION VALUE = 'EU',"
+                        + "  PARTITION VALUE = 'US')")
+                    .insertRow(insertSql, "EU", "eu-book-1", thumbEU1, fullEU1)
+                    .insertRow(insertSql, "EU", "eu-book-2", thumbEU2, fullEU2)
+                    .insertRow(insertSql, "EU", "eu-null",   null,     null)
+                    .insertRow(insertSql, "US", "us-book-1", thumbUS1, fullUS1)
+                    .insertRow(insertSql, "US", "us-book-2", thumbUS2, fullUS2)
+                    .cleanupSql("DROP TABLE " + s + ".MEGA_BLOB CASCADE")
+                    .expectSyntheticKey()
+                    .expectRowCount(5)
+                    .expectBlobColumn("THUMBNAIL")
+                    .expectBlobColumn("FULLSIZE")
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "eu-book-1", thumbEU1)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "eu-book-2", thumbEU2)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "eu-null", null)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "us-book-1", thumbUS1)
+                    .expectBlobBytes("THUMBNAIL", "LABEL", "us-book-2", thumbUS2)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "eu-book-1", fullEU1)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "eu-book-2", fullEU2)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "eu-null", null)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "us-book-1", fullUS1)
+                    .expectBlobBytes("FULLSIZE", "LABEL", "us-book-2", fullUS2)
+                    .run();
+
+            tableTest(s, "SMALL_BLOB")
+                    
+                    .setupSql(
+                        "CREATE COLUMN TABLE " + s + ".SMALL_BLOB ("
+                        + "ID   INTEGER NOT NULL PRIMARY KEY,"
+                        + "NAME NVARCHAR(50) NOT NULL,"
+                        + "DATA BLOB);"
+                        + "INSERT INTO " + s + ".SMALL_BLOB VALUES"
+                        + "  (1, 'hello',     " + smallBlob("Hello".getBytes()) + ");"
+                        + "INSERT INTO " + s + ".SMALL_BLOB VALUES"
+                        + "  (2, 'null_blob', NULL);"
+                        + "INSERT INTO " + s + ".SMALL_BLOB VALUES"
+                        + "  (3, 'world',     " + smallBlob("World".getBytes()) + ")")
+                    .cleanupSql("DROP TABLE " + s + ".SMALL_BLOB CASCADE")
+                    .expectPrimaryKey("ID")
+                    .expectRowCount(3)
+                    .expectBlobColumn("DATA")
+                    .expectBlobBytes("DATA", "ID", 1, "Hello".getBytes())
+                    .expectBlobBytes("DATA", "ID", 3, "World".getBytes())
+                    .expectBlobBytes("DATA", "ID", 2, null)
+                    .run();
+        }
+
+        @Test
+        public void emptyTableCreatesSchema() throws Exception {
+            String s = schemaName();
+            tableTest(s, "EMPTY_TBL")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".EMPTY_TBL ("
+                        + "ID   INTEGER NOT NULL,"
+                        + "NAME NVARCHAR(50) NOT NULL,"
+                        + "PRIMARY KEY (ID))")
+                    .cleanupSql("DROP TABLE " + s + ".EMPTY_TBL CASCADE")
+                    .expectPrimaryKey("ID")
+                    .expectRowCount(0)
+                    .run();
+        }
+
+        @Test
+        public void customQueryTextImport() throws Exception {
+            String s = schemaName();
+            tableTest(s, "QUERY_SRC")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".QUERY_SRC ("
+                        + "ID  INTEGER NOT NULL,"
+                        + "VAL NVARCHAR(50) NOT NULL,"
+                        + "PRIMARY KEY (ID));"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (1, 'a');"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (2, 'b');"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (3, 'c');"
+                        + "INSERT INTO " + s + ".QUERY_SRC VALUES (4, 'd')")
+                    .cleanupSql("DROP TABLE " + s + ".QUERY_SRC CASCADE")
+                    .queryText("SELECT ID, VAL FROM " + s + ".QUERY_SRC"
+                            + " WHERE ID <= 2")
+                    .expectSyntheticKey()
+                    .expectRowCount(2)
+                    .expectRowExists("ID", 1, "VAL", "a")
+                    .expectRowExists("ID", 2, "VAL", "b")
+                    .run();
+        }
+
+        @Test
+        public void syntheticKeyDistinguishesRows() throws Exception {
+            // HANA column store has no PK. Importer assigns synthetic key.
+            String s = schemaName();
+            tableTest(s, "SYNTH_TBL")
+                    
+                    .setupSql(
+                        "CREATE COLUMN TABLE " + s + ".SYNTH_TBL ("
+                        + "SEQ  INTEGER NOT NULL,"
+                        + "NAME NVARCHAR(50) NOT NULL);"
+                        + "INSERT INTO " + s + ".SYNTH_TBL VALUES (1, 'same');"
+                        + "INSERT INTO " + s + ".SYNTH_TBL VALUES (2, 'same');"
+                        + "INSERT INTO " + s + ".SYNTH_TBL VALUES (3, 'same')")
+                    .cleanupSql("DROP TABLE " + s + ".SYNTH_TBL CASCADE")
+                    .expectSyntheticKey()
+                    .expectRowCount(3)
+                    .expectRowExists("SEQ", 1, "NAME", "same")
+                    .expectRowExists("SEQ", 2, "NAME", "same")
+                    .expectRowExists("SEQ", 3, "NAME", "same")
+                    .run();
+        }
+
+        @Test
+        public void skipUnsupportedColumns() throws Exception {
+            String s = schemaName();
+            tableTest(s, "SKIP_HANA")
+                    
+                    .withOptions(opts -> opts.setSkipUnknownTypes(true))
+                    .setupSql(
+                        "CREATE TABLE " + s + ".SKIP_HANA ("
+                        + "ID     INTEGER NOT NULL,"
+                        + "NAME   NVARCHAR(50) NOT NULL,"
+                        + "TAGS   INTEGER ARRAY,"
+                        + "LABELS NVARCHAR(20) ARRAY,"
+                        + "PRIMARY KEY (ID));"
+                        + "INSERT INTO " + s + ".SKIP_HANA"
+                        + " VALUES (1, 'a', ARRAY(1, 2, 3), ARRAY('x', 'y'));"
+                        + "INSERT INTO " + s + ".SKIP_HANA"
+                        + " VALUES (2, 'b', ARRAY(4, 5), ARRAY('z'))")
+                    .cleanupSql("DROP TABLE " + s + ".SKIP_HANA CASCADE")
+                    .expectPrimaryKey("ID")
+                    .expectSkippedColumns("TAGS", "LABELS")
+                    .expectRowCount(2)
+                    .expectRowExists("ID", 1, "NAME", "a")
+                    .run();
+        }
+
+        @Test
+        public void clobContentImport() throws Exception {
+            String s = schemaName();
+            int size = 524288;
+            String big = repeat("Z", size);
+            tableTest(s, "CLOB_TBL")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".CLOB_TBL ("
+                        + "ID   INTEGER NOT NULL PRIMARY KEY,"
+                        + "NOTE CLOB);"
+                        + "INSERT INTO " + s + ".CLOB_TBL VALUES (2, NULL);"
+                        + "INSERT INTO " + s + ".CLOB_TBL VALUES (3, '')")
+                    .insertRow("INSERT INTO " + s + ".CLOB_TBL VALUES (?, ?)",
+                            1, big)
+                    .cleanupSql("DROP TABLE " + s + ".CLOB_TBL CASCADE")
+                    .expectPrimaryKey("ID")
+                    .expectRowCount(3)
+                    .expectClobColumn("NOTE")
+                    .expectClobContent("NOTE", "ID", 1, big)
+                    .expectClobContent("NOTE", "ID", 2, null)
+                    .expectClobContent("NOTE", "ID", 3, "")
+                    .run();
+        }
+    }
+
+    @Nested class TableTestsRow extends HanaTableCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TableTestsArrow extends HanaTableCases {
+        @Override public boolean useArrow() { return true; }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/MariaDbLoader.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/MariaDbLoader.java
@@ -1,0 +1,80 @@
+package tech.ydb.importer.integration.sources.mariadb;
+
+import tech.ydb.importer.integration.verification.DialectLoader;
+import tech.ydb.importer.integration.verification.LogicalType;
+import tech.ydb.importer.integration.verification.TableScenario.PartitionStyle;
+import tech.ydb.importer.integration.verification.TableScenario;
+
+public class MariaDbLoader extends DialectLoader {
+
+    public static final MariaDbLoader INSTANCE = new MariaDbLoader();
+
+    protected MariaDbLoader() {
+    }
+
+    @Override
+    protected String toDdl(LogicalType type) {
+        switch (type) {
+            case INT32:           return "INT";
+            case INT64:           return "BIGINT";
+            case DECIMAL_18_4:    return "DECIMAL(18, 4)";
+            case STRING:          return "VARCHAR(255)";
+            case BOOL:            return "BOOLEAN";
+            case DATE:            return "DATE";
+            case DATETIME:        return "DATETIME";
+            default:
+                throw new IllegalArgumentException("Unsupported: " + type);
+        }
+    }
+
+    @Override
+    protected String blobDdlType() {
+        return "MEDIUMBLOB";
+    }
+
+    @Override
+    protected void appendEngine(StringBuilder ddl, TableScenario scenario) {
+        ddl.append(" ENGINE=InnoDB");
+    }
+
+    @Override
+    protected void appendPartition(StringBuilder ddl, PartitionStyle style,
+                                   String column, TableScenario scenario) {
+        switch (style) {
+            case HASH_INT:
+                ddl.append(" PARTITION BY HASH(").append(column)
+                        .append(") PARTITIONS ")
+                        .append(partitionCount(scenario));
+                break;
+            case RANGE_INT: {
+                long[] b = rangeIntBoundaries(scenario);
+                ddl.append(" PARTITION BY RANGE(").append(column).append(") (");
+                for (int i = 0; i < b.length; i++) {
+                    ddl.append("PARTITION p").append(i)
+                            .append(" VALUES LESS THAN (").append(b[i])
+                            .append("),");
+                }
+                ddl.append("PARTITION pmax VALUES LESS THAN MAXVALUE)");
+                break;
+            }
+            case RANGE_DATE:
+                ddl.append(" PARTITION BY RANGE(YEAR(").append(column)
+                        .append(")) (")
+                        .append("PARTITION p2024 VALUES LESS THAN (2025),")
+                        .append("PARTITION p2025 VALUES LESS THAN (2026),")
+                        .append("PARTITION p2026 VALUES LESS THAN (2027),")
+                        .append("PARTITION pmax VALUES LESS THAN MAXVALUE)");
+                break;
+            case LIST_STRING:
+                ddl.append(" PARTITION BY LIST COLUMNS(").append(column)
+                        .append(") (")
+                        .append("PARTITION p_card VALUES IN ('card'),")
+                        .append("PARTITION p_cash VALUES IN ('cash'),")
+                        .append("PARTITION p_transfer VALUES IN ('transfer'),")
+                        .append("PARTITION p_crypto VALUES IN ('crypto'))");
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/MariaDbTestContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/MariaDbTestContainer.java
@@ -1,0 +1,19 @@
+package tech.ydb.importer.integration.sources.mariadb;
+
+import org.testcontainers.mariadb.MariaDBContainer;
+
+public final class MariaDbTestContainer {
+
+    public static final String IMAGE = "mariadb:11.8.6";
+
+    private MariaDbTestContainer() {
+    }
+
+    @SuppressWarnings("resource")
+    public static MariaDBContainer create(String dbName) {
+        return new MariaDBContainer(IMAGE)
+                .withDatabaseName(dbName)
+                .withUsername("test")
+                .withPassword("test");
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/MariaDbYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/MariaDbYdbImporterTest.java
@@ -1,0 +1,147 @@
+package tech.ydb.importer.integration.sources.mariadb;
+
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.mariadb.MariaDBContainer;
+
+import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.integration.sources.mysql.AbstractMySqlCompatibleTableCases;
+import tech.ydb.importer.integration.sources.mysql.AbstractMySqlCompatibleTypeCases;
+
+/** MariaDB integration tests. */
+public class MariaDbYdbImporterTest {
+
+    private static final String DB_NAME = "import_test";
+
+    private static MariaDBContainer mariaContainer;
+    private static TimeZone originalTz;
+
+    @BeforeAll
+    static void startMariaDb() {
+        originalTz = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        mariaContainer = MariaDbTestContainer.create(DB_NAME);
+        mariaContainer.start();
+    }
+
+    @AfterAll
+    static void stopMariaDb() {
+        if (mariaContainer != null) {
+            mariaContainer.stop();
+            mariaContainer = null;
+        }
+        if (originalTz != null) {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+
+    abstract class MariaDbTypeCases
+            extends AbstractMySqlCompatibleTypeCases {
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(mariaContainer, SourceType.MARIADB, DB_NAME);
+        }
+    }
+
+    @Nested class TypeTestsRow extends MariaDbTypeCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TypeTestsArrow extends MariaDbTypeCases {
+        @Override public boolean useArrow() { return true; }
+    }
+
+    abstract class MariaDbTableCases
+            extends AbstractMySqlCompatibleTableCases {
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(mariaContainer, SourceType.MARIADB, DB_NAME);
+        }
+
+        @Test
+        public void skipUnsupportedUuidColumn() throws Exception {
+            String s = schemaName();
+            tableTest(s, "skip_uuid")
+                    
+                    .withOptions(opts -> opts.setSkipUnknownTypes(true))
+                    .setupSql(
+                        "CREATE TABLE " + s + ".skip_uuid ("
+                        + "id INT NOT NULL PRIMARY KEY,"
+                        + "name VARCHAR(50) NOT NULL,"
+                        + "uid UUID"
+                        + ") ENGINE=InnoDB;"
+                        + "INSERT INTO " + s + ".skip_uuid VALUES"
+                        + " (1,'a',UUID()),"
+                        + "(2,'b',UUID())")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + ".skip_uuid")
+                    .expectPrimaryKey("id")
+                    .expectSkippedColumns("uid")
+                    .expectRowCount(2)
+                    .expectRowExists("id", 1, "name", "a")
+                    .run();
+        }
+
+        @Test
+        public void rangePartitioning() throws Exception {
+            String s = schemaName();
+            tableTest(s, "part_range")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".part_range ("
+                        + "id INT NOT NULL,"
+                        + "region_id INT NOT NULL,"
+                        + "amount INT NOT NULL,"
+                        + "PRIMARY KEY (id, region_id)"
+                        + ") ENGINE=InnoDB"
+                        + " PARTITION BY RANGE (region_id) ("
+                        + "  PARTITION p_low VALUES LESS THAN (100),"
+                        + "  PARTITION p_mid VALUES LESS THAN (200),"
+                        + "  PARTITION p_high VALUES LESS THAN MAXVALUE"
+                        + ");"
+                        + "INSERT INTO " + s + ".part_range VALUES"
+                        + " (1,10,100),(2,50,200),"
+                        + "(3,110,300),(4,250,400)")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + ".part_range")
+                    .expectPrimaryKey("id", "region_id")
+                    .expectRowCount(4)
+                    .expectRowExists("id", 1, "amount", 100)
+                    .expectRowExists("id", 4, "amount", 400)
+                    .run();
+        }
+
+        @Test
+        public void singlePartitionNotPartitioned() throws Exception {
+            String s = schemaName();
+            tableTest(s, "part_single")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".part_single ("
+                        + "id INT NOT NULL PRIMARY KEY"
+                        + ") ENGINE=InnoDB"
+                        + " PARTITION BY RANGE (id) ("
+                        + "  PARTITION p_all VALUES LESS THAN MAXVALUE"
+                        + ");"
+                        + "INSERT INTO " + s + ".part_single VALUES"
+                        + " (1),(2)")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + ".part_single")
+                    .expectPrimaryKey("id")
+                    .expectRowCount(2)
+                    .run();
+        }
+    }
+
+    @Nested class TableTestsRow extends MariaDbTableCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TableTestsArrow extends MariaDbTableCases {
+        @Override public boolean useArrow() { return true; }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/ColumnStoreContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/ColumnStoreContainer.java
@@ -1,0 +1,93 @@
+package tech.ydb.importer.integration.sources.mariadb.columnstore;
+
+import java.time.Duration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.mariadb.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public final class ColumnStoreContainer {
+
+    public static final String DEFAULT_IMAGE = "mariadb/columnstore:23.02.4";
+    public static final String DEFAULT_DB_NAME = "cs_test";
+    public static final String DEFAULT_USERNAME = "csuser";
+    public static final String DEFAULT_PASSWORD = "C0lumnStore!";
+
+    private static final int MYSQL_PORT = 3306;
+
+    private final String imageName;
+    private final String dbName;
+    private final String userName;
+    private final String password;
+    private final GenericContainer<?> container;
+    private MariaDBContainer jdbcView;
+
+    public ColumnStoreContainer() {
+        this(DEFAULT_IMAGE, DEFAULT_DB_NAME, DEFAULT_USERNAME, DEFAULT_PASSWORD);
+    }
+
+    @SuppressWarnings("resource")
+    public ColumnStoreContainer(String imageName, String dbName,
+                                String userName, String password) {
+        this.imageName = imageName;
+        this.dbName = dbName;
+        this.userName = userName;
+        this.password = password;
+        this.container = new GenericContainer<>(imageName)
+                .withExposedPorts(MYSQL_PORT)
+                .withSharedMemorySize(512 * 1024 * 1024L)
+                .withEnv("PM1", "mcs1")
+                .withEnv("ADMIN_HOST", "%")
+                .withEnv("ADMIN_PASS", password)
+                .withCreateContainerCmdModifier(
+                        cmd -> cmd.withHostName("mcs1"))
+                .waitingFor(Wait.forLogMessage(
+                        ".*ready for connections.*", 1))
+                .withStartupTimeout(Duration.ofMinutes(3));
+    }
+
+    public void start() throws Exception {
+        container.start();
+        container.execInContainer("provision", "mcs1");
+        container.execInContainer("mariadb", "-uroot", "-p" + password, "-e",
+                "CREATE DATABASE IF NOT EXISTS " + dbName + ";"
+                + "CREATE USER IF NOT EXISTS '" + userName
+                + "'@'%' IDENTIFIED BY '" + password + "';"
+                + "GRANT ALL PRIVILEGES ON *.* TO '"
+                + userName + "'@'%'; FLUSH PRIVILEGES;");
+        jdbcView = buildJdbcView();
+    }
+
+    public void stop() {
+        container.stop();
+        jdbcView = null;
+    }
+
+    public MariaDBContainer getJdbcContainer() {
+        if (jdbcView == null) {
+            throw new IllegalStateException(
+                    "ColumnStoreContainer not started");
+        }
+        return jdbcView;
+    }
+
+    public String getDatabaseName() {
+        return dbName;
+    }
+
+    private MariaDBContainer buildJdbcView() {
+        final String jdbcUrl = "jdbc:mariadb://localhost:"
+                + container.getMappedPort(MYSQL_PORT) + "/" + dbName;
+        DockerImageName image = DockerImageName.parse(imageName)
+                .asCompatibleSubstituteFor("mariadb");
+        return new MariaDBContainer(image) {
+            @Override public String getJdbcUrl() { return jdbcUrl; }
+            @Override public String getUsername() { return userName; }
+            @Override public String getPassword() { return password; }
+            @Override public String getDriverClassName() {
+                return "org.mariadb.jdbc.Driver";
+            }
+        };
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/ColumnStoreContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/ColumnStoreContainer.java
@@ -77,7 +77,7 @@ public final class ColumnStoreContainer {
     }
 
     private MariaDBContainer buildJdbcView() {
-        final String jdbcUrl = "jdbc:mariadb://localhost:"
+        final String jdbcUrl = "jdbc:mariadb://" + container.getHost() + ":"
                 + container.getMappedPort(MYSQL_PORT) + "/" + dbName;
         DockerImageName image = DockerImageName.parse(imageName)
                 .asCompatibleSubstituteFor("mariadb");

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/MariaDbColumnStoreLoader.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/MariaDbColumnStoreLoader.java
@@ -1,0 +1,42 @@
+package tech.ydb.importer.integration.sources.mariadb.columnstore;
+
+import tech.ydb.importer.integration.verification.DialectLoader;
+import tech.ydb.importer.integration.verification.LogicalType;
+import tech.ydb.importer.integration.verification.TableScenario;
+
+public final class MariaDbColumnStoreLoader extends DialectLoader {
+
+    public static final MariaDbColumnStoreLoader INSTANCE =
+            new MariaDbColumnStoreLoader();
+
+    private MariaDbColumnStoreLoader() {
+    }
+
+    @Override
+    protected String toDdl(LogicalType type) {
+        switch (type) {
+            case INT32:           return "INT";
+            case INT64:           return "BIGINT";
+            case DECIMAL_18_4:    return "DECIMAL(18, 4)";
+            case STRING:          return "VARCHAR(255)";
+            case BOOL:            return "BOOLEAN";
+            case DATE:            return "DATE";
+            case DATETIME:        return "DATETIME";
+            default:
+                throw new IllegalArgumentException("Unsupported: " + type);
+        }
+    }
+
+    @Override
+    protected void appendEngine(StringBuilder ddl, TableScenario scenario) {
+        ddl.append(" ENGINE=Columnstore");
+    }
+
+    @Override
+    public Object adjustExpected(LogicalType type, Object expected) {
+        if (type == LogicalType.BOOL && expected instanceof Boolean) {
+            return ((Boolean) expected) ? 1 : 0;
+        }
+        return expected;
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/MariaDbColumnStoreYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/MariaDbColumnStoreYdbImporterTest.java
@@ -1,0 +1,487 @@
+package tech.ydb.importer.integration.sources.mariadb.columnstore;
+
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.integration.sources.mysql.AbstractMySqlCompatibleTableCases;
+import tech.ydb.importer.integration.sources.mysql.AbstractMySqlCompatibleTypeCases;
+import tech.ydb.table.values.PrimitiveType;
+
+/** MariaDB ColumnStore integration tests. */
+public class MariaDbColumnStoreYdbImporterTest {
+
+    private static final String DB_NAME = ColumnStoreContainer.DEFAULT_DB_NAME;
+
+    private static ColumnStoreContainer csContainer;
+    private static JdbcDatabaseContainer<?> jdbcContainer;
+    private static TimeZone originalTz;
+
+    @BeforeAll
+    static void startColumnStore() throws Exception {
+        originalTz = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+        csContainer = new ColumnStoreContainer();
+        csContainer.start();
+        jdbcContainer = csContainer.getJdbcContainer();
+    }
+
+    @AfterAll
+    static void stopColumnStore() {
+        if (csContainer != null) {
+            csContainer.stop();
+            csContainer = null;
+        }
+        jdbcContainer = null;
+        if (originalTz != null) {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+
+    abstract class CsTypeCases
+            extends AbstractMySqlCompatibleTypeCases {
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(jdbcContainer, SourceType.MARIADB, DB_NAME);
+        }
+
+        @Override
+        protected String createTableSuffix() {
+            return " ENGINE=Columnstore";
+        }
+
+        // ColumnStore BOOLEAN reports as TINYINT, not BIT.
+        @Test
+        @Override
+        public void booleanMaps() throws Exception {
+            typeTest()
+                    .column("TINYINT NOT NULL", PrimitiveType.Int32)
+                        .value("1", 1)
+                        .value("0", 0)
+                    .execute();
+        }
+
+        // ColumnStore integer ranges slightly smaller than standard.
+        @Test
+        @Override
+        public void tinyintMapsToInt32() throws Exception {
+            typeTest()
+                    .column("TINYINT NOT NULL", PrimitiveType.Int32)
+                        .value("126", 126)
+                        .value("-126", -126)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        public void int32Boundaries() throws Exception {
+            typeTest()
+                    .column("INT NOT NULL", PrimitiveType.Int32)
+                        .value("0", 0)
+                        .value("-1", -1)
+                        .value("2147483646", 2147483646)
+                    .column("INT", PrimitiveType.Int32.makeOptional())
+                        .value("42", 42)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        public void int64Boundaries() throws Exception {
+            typeTest()
+                    .column("BIGINT NOT NULL", PrimitiveType.Int64)
+                        .value("0", 0L)
+                        .value("999999999999999", 999999999999999L)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        public void smallintMapsToInt32() throws Exception {
+            typeTest()
+                    .column("SMALLINT NOT NULL", PrimitiveType.Int32)
+                        .value("32766", 32766)
+                        .value("-32766", -32766)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        public void mediumintMapsToInt32() throws Exception {
+            typeTest()
+                    .column("MEDIUMINT NOT NULL", PrimitiveType.Int32)
+                        .value("8388606", 8388606)
+                        .value("-8388606", -8388606)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        @Disabled("ColumnStore does not support JSON/ENUM")
+        public void jsonAndEnumMapToText() throws Exception {
+        }
+
+        @Test
+        @Override
+        @Disabled("ColumnStore does not support VARBINARY")
+        public void binaryAndVarbinary() throws Exception {
+        }
+
+        @Test
+        @Override
+        public void stringTypesMapToText() throws Exception {
+            typeTest()
+                    .column("VARCHAR(100) NOT NULL", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("'кириллица'", "кириллица")
+                    .column("TEXT NOT NULL", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("'text value'", "text value")
+                    .column("VARCHAR(100)",
+                            PrimitiveType.Text.makeOptional())
+                        .value("'hello'", "hello")
+                        .value("''", null) // empty string -> NULL
+                    .execute();
+        }
+
+        @Test
+        @Override
+        @Disabled("ColumnStore DECIMAL precision limited to 18")
+        public void highPrecisionDecimalMapsToDecimal() throws Exception {
+        }
+    }
+
+    @Nested class TypeTestsRow extends CsTypeCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TypeTestsArrow extends CsTypeCases {
+        @Override public boolean useArrow() { return true; }
+    }
+
+    abstract class CsTableCases
+            extends AbstractMySqlCompatibleTableCases {
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(jdbcContainer, SourceType.MARIADB, DB_NAME);
+        }
+
+        @Override
+        protected String engine() {
+            return "Columnstore";
+        }
+
+        // ColumnStore cannot have PRIMARY KEY in DDL.
+        @Test
+        @Override
+        public void customQueryTextImport() throws Exception {
+            String s = schemaName();
+            tableTest(s, "query_src")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".query_src ("
+                        + "id INT NOT NULL,"
+                        + "val VARCHAR(50) NOT NULL"
+                        + ") ENGINE=Columnstore;"
+                        + "INSERT INTO " + s + ".query_src VALUES"
+                        + " (1,'a'),(2,'b'),(3,'c'),(4,'d')")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + ".query_src")
+                    .queryText("SELECT id, val FROM " + s
+                            + ".query_src WHERE id <= 2")
+                    .expectSyntheticKey()
+                    .expectRowCount(2)
+                    .expectRowExists("id", 1, "val", "a")
+                    .expectRowExists("id", 2, "val", "b")
+                    .run();
+        }
+
+        @Test
+        @Override
+        public void emptyTableCreatesSchema() throws Exception {
+            String s = schemaName();
+            tableTest(s, "empty_tbl")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".empty_tbl ("
+                        + "id INT NOT NULL,"
+                        + "name VARCHAR(100) NOT NULL"
+                        + ") ENGINE=Columnstore")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + ".empty_tbl")
+                    .expectSyntheticKey()
+                    .expectRowCount(0)
+                    .run();
+        }
+
+        /*
+         * ColumnStore ignores PRIMARY KEY / UNIQUE,
+         * all tables fall back to synthetic key.
+         */
+        @Test
+        @Override
+        public void primaryKeySelection() throws Exception {
+            String s = schemaName();
+            String e = engine();
+            importTogether()
+                    
+                    .add(tableTest(s, "pk_composite")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".pk_composite ("
+                                + "region_id INT NOT NULL,"
+                                + "city_id INT NOT NULL,"
+                                + "name VARCHAR(100) NOT NULL"
+                                + ") ENGINE=" + e + ";"
+                                + "INSERT INTO " + s
+                                + ".pk_composite VALUES"
+                                + " (1,10,'Moscow'),(1,20,'SPb'),"
+                                + "(2,30,'Berlin')")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + s + ".pk_composite")
+                            .expectSyntheticKey()
+                            .expectRowCount(3)
+                            .expectRowExists(
+                                    "region_id", 1, "city_id", 10,
+                                    "name", "Moscow"))
+                    .add(tableTest(s, "pk_over_unique")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".pk_over_unique ("
+                                + "id BIGINT NOT NULL,"
+                                + "code VARCHAR(20) NOT NULL,"
+                                + "val INT"
+                                + ") ENGINE=" + e + ";"
+                                + "INSERT INTO " + s
+                                + ".pk_over_unique"
+                                + " VALUES (1,'A',10),(2,'B',20)")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + s + ".pk_over_unique")
+                            .expectSyntheticKey()
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1L, "code", "A"))
+                    .add(tableTest(s, "uq_as_key")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".uq_as_key ("
+                                + "a BIGINT NOT NULL,"
+                                + "b VARCHAR(10) NOT NULL"
+                                + ") ENGINE=" + e + ";"
+                                + "INSERT INTO " + s + ".uq_as_key"
+                                + " VALUES (1,'x'),(2,'y')")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + s + ".uq_as_key")
+                            .expectSyntheticKey()
+                            .expectRowCount(2))
+                    .run();
+        }
+
+        @Test
+        @Override
+        @Disabled("ColumnStore engine does not support PARTITION BY")
+        public void partitionedImport() throws Exception {
+        }
+
+        // ColumnStore engine does not support PARTITION BY or PRIMARY KEY in DDL.
+        @Test
+        @Override
+        public void partitionedMultiBlobSynthKey() throws Exception {
+            String s = schemaName();
+            String e = engine();
+
+            byte[] thumb1 = "thumb-1".getBytes();
+            byte[] thumb2 = "thumb-2".getBytes();
+            byte[] thumb3 = "thumb-3".getBytes();
+            byte[] thumb4 = "thumb-4".getBytes();
+
+            byte[] full1 = filled(500_000, (byte) 0x11);
+            byte[] full2 = filled(500_000, (byte) 0x22);
+            byte[] full3 = filled(500_000, (byte) 0x33);
+            byte[] full4 = filled(500_000, (byte) 0x44);
+
+            tableTest(s, "mega_blob")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".mega_blob ("
+                        + "  label     VARCHAR(30),"
+                        + "  thumbnail MEDIUMBLOB,"
+                        + "  fullsize  MEDIUMBLOB"
+                        + ") ENGINE=" + e + ";"
+                        + "INSERT INTO " + s + ".mega_blob VALUES"
+                        + "('book-1'," + smallBlob(thumb1)
+                        + "," + bigBlob("11", 500_000) + "),"
+                        + "('book-2'," + smallBlob(thumb2)
+                        + "," + bigBlob("22", 500_000) + "),"
+                        + "('null-row',NULL,NULL),"
+                        + "('book-3'," + smallBlob(thumb3)
+                        + "," + bigBlob("33", 500_000) + "),"
+                        + "('book-4'," + smallBlob(thumb4)
+                        + "," + bigBlob("44", 500_000) + ")")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + ".mega_blob")
+                    .expectSyntheticKey()
+                    .expectRowCount(5)
+                    .expectBlobColumn("thumbnail")
+                    .expectBlobColumn("fullsize")
+                    .expectBlobBytes("thumbnail", "label", "book-1", thumb1)
+                    .expectBlobBytes("thumbnail", "label", "book-2", thumb2)
+                    .expectBlobBytes("thumbnail", "label", "null-row", null)
+                    .expectBlobBytes("thumbnail", "label", "book-3", thumb3)
+                    .expectBlobBytes("thumbnail", "label", "book-4", thumb4)
+                    .expectBlobBytes("fullsize", "label", "book-1", full1)
+                    .expectBlobBytes("fullsize", "label", "book-2", full2)
+                    .expectBlobBytes("fullsize", "label", "null-row", null)
+                    .expectBlobBytes("fullsize", "label", "book-3", full3)
+                    .expectBlobBytes("fullsize", "label", "book-4", full4)
+                    .run();
+
+            tableTest(s, "small_blob")
+                    
+                    .setupSql(
+                        "CREATE TABLE " + s + ".small_blob ("
+                        + "  id   INT NOT NULL,"
+                        + "  name VARCHAR(50) NOT NULL,"
+                        + "  data MEDIUMBLOB"
+                        + ") ENGINE=" + e + ";"
+                        + "INSERT INTO " + s + ".small_blob VALUES"
+                        + "  (1, 'hello',     " + smallBlob("Hello".getBytes()) + "),"
+                        + "  (2, 'null_blob', NULL),"
+                        + "  (3, 'world',     " + smallBlob("World".getBytes()) + ")")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + s + ".small_blob")
+                    .expectSyntheticKey()
+                    .expectRowCount(3)
+                    .expectBlobColumn("data")
+                    .expectBlobBytes("data", "id", 1, "Hello".getBytes())
+                    .expectBlobBytes("data", "id", 3, "World".getBytes())
+                    .expectBlobBytes("data", "id", 2, null)
+                    .run();
+        }
+
+        @Test
+        @Override
+        public void rangeSplitsByColumnType() throws Exception {
+            String s = schemaName();
+            importTogether()
+                    .add(tableTest(s, "split_int")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".split_int ("
+                                + "  id  INT NOT NULL,"
+                                + "  val INT NOT NULL"
+                                + ") ENGINE=Columnstore;"
+                                + "INSERT INTO " + s + ".split_int VALUES"
+                                + "  (1,5),(2,12),(3,28),(4,45),"
+                                + "  (5,60),(6,73),(7,88),(8,99)")
+                            .cleanupSql("DROP TABLE IF EXISTS " + s + ".split_int")
+                            .splitBy("val").splitFrom("0").splitTo("100").splitCount(4)
+                            .expectSyntheticKey()
+                            .expectRowCount(8))
+                    .add(tableTest(s, "split_dec")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".split_dec ("
+                                + "  id  INT NOT NULL,"
+                                + "  val DECIMAL(10,2) NOT NULL"
+                                + ") ENGINE=Columnstore;"
+                                + "INSERT INTO " + s + ".split_dec VALUES"
+                                + "  (1,1.50),(2,10.25),(3,33.75),"
+                                + "  (4,50.00),(5,75.50),(6,99.99)")
+                            .cleanupSql("DROP TABLE IF EXISTS " + s + ".split_dec")
+                            .splitBy("val").splitFrom("0").splitTo("100").splitCount(3)
+                            .expectSyntheticKey()
+                            .expectRowCount(6))
+                    .add(tableTest(s, "split_dbl")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".split_dbl ("
+                                + "  id  INT NOT NULL,"
+                                + "  val DOUBLE NOT NULL"
+                                + ") ENGINE=Columnstore;"
+                                + "INSERT INTO " + s + ".split_dbl VALUES"
+                                + "  (1,0.1),(2,1.5),(3,3.7),(4,5.0),(5,7.2)")
+                            .cleanupSql("DROP TABLE IF EXISTS " + s + ".split_dbl")
+                            .splitBy("val").splitFrom("0").splitTo("10").splitCount(3)
+                            .expectSyntheticKey()
+                            .expectRowCount(5))
+                    .add(tableTest(s, "split_date")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".split_date ("
+                                + "  id  INT NOT NULL,"
+                                + "  val DATE NOT NULL"
+                                + ") ENGINE=Columnstore;"
+                                + "INSERT INTO " + s + ".split_date VALUES"
+                                + "  (1,'2024-01-15'),(2,'2024-03-10'),"
+                                + "  (3,'2024-06-01'),(4,'2024-09-20'),"
+                                + "  (5,'2024-12-25')")
+                            .cleanupSql("DROP TABLE IF EXISTS " + s + ".split_date")
+                            .splitBy("val")
+                                .splitFrom("2024-01-01").splitTo("2025-01-01")
+                                .splitCount(4)
+                            .expectSyntheticKey()
+                            .expectRowCount(5))
+                    .add(tableTest(s, "split_ts")
+                            .setupSql(
+                                "CREATE TABLE " + s + ".split_ts ("
+                                + "  id  INT NOT NULL,"
+                                + "  val DATETIME NOT NULL"
+                                + ") ENGINE=Columnstore;"
+                                + "INSERT INTO " + s + ".split_ts VALUES"
+                                + "  (1,'2024-01-15 10:00:00'),"
+                                + "  (2,'2024-06-01 14:30:00'),"
+                                + "  (3,'2024-12-25 23:59:59')")
+                            .cleanupSql("DROP TABLE IF EXISTS " + s + ".split_ts")
+                            .splitBy("val")
+                                .splitFrom("2024-01-01 00:00:00")
+                                .splitTo("2025-01-01 00:00:00")
+                                .splitCount(3)
+                            .expectSyntheticKey()
+                            .expectRowCount(3))
+                    .run();
+        }
+
+        @Test
+        @Override
+        public void clobContentImport() throws Exception {
+            String s = schemaName();
+            String bigText = repeat("Y", 524288);
+
+            tableTest(s, "clob_docs")
+                    .setupSql(
+                        "CREATE TABLE " + s + ".clob_docs ("
+                        + "  id    INT NOT NULL,"
+                        + "  short TEXT,"
+                        + "  large LONGTEXT"
+                        + ") ENGINE=Columnstore")
+                    .insertRow("INSERT INTO " + s + ".clob_docs VALUES (?, ?, ?)",
+                            1, "YDB", bigText)
+                    .insertRow("INSERT INTO " + s + ".clob_docs VALUES (?, ?, ?)",
+                            2, null, null)
+                    .insertRow("INSERT INTO " + s + ".clob_docs VALUES (?, ?, ?)",
+                            3, "", "")
+                    .cleanupSql("DROP TABLE IF EXISTS " + s + ".clob_docs")
+                    .clobColumns("short", "large")
+                    .expectSyntheticKey()
+                    .expectRowCount(3)
+                    .expectClobColumn("short")
+                    .expectClobColumn("large")
+                    .expectClobContent("short", "id", 1, "YDB")
+                    .expectClobContent("large", "id", 1, bigText)
+                    .expectClobContent("short", "id", 2, null)
+                    .expectClobContent("large", "id", 2, null)
+                    .expectClobContent("short", "id", 3, null)
+                    .expectClobContent("large", "id", 3, null)
+                    .run();
+        }
+    }
+
+    @Nested class TableTestsRow extends CsTableCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TableTestsArrow extends CsTableCases {
+        @Override public boolean useArrow() { return true; }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaLoader.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaLoader.java
@@ -1,0 +1,67 @@
+package tech.ydb.importer.integration.sources.vertica;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import tech.ydb.importer.integration.verification.DialectLoader;
+import tech.ydb.importer.integration.verification.LogicalType;
+import tech.ydb.importer.integration.verification.TableScenario.PartitionStyle;
+import tech.ydb.importer.integration.verification.TableScenario;
+
+public final class VerticaLoader extends DialectLoader {
+
+    public static final VerticaLoader INSTANCE = new VerticaLoader();
+
+    private VerticaLoader() {
+    }
+
+    @Override
+    protected String toDdl(LogicalType type) {
+        switch (type) {
+            case INT32:           return "INTEGER";
+            case INT64:           return "BIGINT";
+            case DECIMAL_18_4:    return "NUMERIC(18, 4)";
+            case STRING:          return "VARCHAR(255)";
+            case BOOL:            return "BOOLEAN";
+            case DATE:            return "DATE";
+            case DATETIME:        return "TIMESTAMP";
+            default:
+                throw new IllegalArgumentException("Unsupported: " + type);
+        }
+    }
+
+    @Override
+    protected String blobDdlType() {
+        return "LONG VARBINARY";
+    }
+
+    @Override
+    public boolean supportsMultiRowInsert() {
+        return false;
+    }
+
+    @Override
+    public Set<PartitionStyle> supportedPartitions() {
+        return EnumSet.of(PartitionStyle.HASH_INT, PartitionStyle.RANGE_INT,
+                PartitionStyle.RANGE_DATE);
+    }
+
+    @Override
+    protected void appendPartition(StringBuilder ddl, PartitionStyle style,
+                                   String column, TableScenario scenario) {
+        int p = partitionCount(scenario);
+        switch (style) {
+            case HASH_INT:
+            case RANGE_INT:
+                ddl.append(" PARTITION BY ").append(column)
+                        .append(" % ").append(p);
+                break;
+            case RANGE_DATE:
+                ddl.append(" PARTITION BY EXTRACT(YEAR FROM ")
+                        .append(column).append(") % ").append(p);
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaTestContainer.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaTestContainer.java
@@ -1,0 +1,57 @@
+package tech.ydb.importer.integration.sources.vertica;
+
+import java.util.Collections;
+
+import com.github.dockerjava.api.model.Ulimit;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public final class VerticaTestContainer
+        extends JdbcDatabaseContainer<VerticaTestContainer> {
+
+    public static final String DEFAULT_IMAGE = "vertica-ce-bench:latest";
+
+    private static final int VERTICA_PORT = 5433;
+
+    public VerticaTestContainer() {
+        this(DEFAULT_IMAGE);
+    }
+
+    public VerticaTestContainer(String imageName) {
+        super(DockerImageName.parse(imageName));
+        addExposedPort(VERTICA_PORT);
+        withStartupTimeoutSeconds(300);
+        withConnectTimeoutSeconds(120);
+        withCreateContainerCmdModifier(cmd ->
+                cmd.getHostConfig().withUlimits(
+                        Collections.singletonList(
+                                new Ulimit("nofile", 65536L, 65536L))));
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "com.vertica.jdbc.Driver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:vertica://" + getHost() + ":"
+                + getMappedPort(VERTICA_PORT) + "/VMart";
+    }
+
+    @Override
+    public String getUsername() {
+        return "dbadmin";
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1";
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaYdbImporterTest.java
@@ -1,0 +1,677 @@
+package tech.ydb.importer.integration.sources.vertica;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.config.TableOptions.DateConv;
+import tech.ydb.importer.integration.tabletest.AbstractYdbImporterTableTest;
+import tech.ydb.importer.integration.typetest.AbstractYdbImporterTypeTest;
+import tech.ydb.table.values.DecimalType;
+import tech.ydb.table.values.PrimitiveType;
+
+/** Vertica integration tests. */
+public class VerticaYdbImporterTest {
+
+    private static VerticaTestContainer verticaContainer;
+    private static TimeZone originalTz;
+
+    @BeforeAll
+    static void startVertica() {
+        originalTz = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        verticaContainer = new VerticaTestContainer();
+        verticaContainer.start();
+    }
+
+    @AfterAll
+    static void stopVertica() {
+        if (verticaContainer != null) {
+            verticaContainer.stop();
+            verticaContainer = null;
+        }
+        if (originalTz != null) {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+
+    abstract class VerticaTypeCases extends AbstractYdbImporterTypeTest {
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(verticaContainer, SourceType.VERTICA, "public");
+        }
+
+        @Override
+        protected String createTableSuffix() {
+            return "";
+        }
+
+        @Test
+        public void integerMapsToInt64() throws Exception {
+            typeTest()
+                    .column("INT NOT NULL", PrimitiveType.Int64)
+                        .value("0", 0L)
+                        .value("-1", -1L)
+                        .value("2147483647", 2147483647L)
+                    .column("INT", PrimitiveType.Int64.makeOptional())
+                        .value("42", 42L)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void smallintAndTinyintMapToInt64() throws Exception {
+            typeTest()
+                    .column("SMALLINT NOT NULL", PrimitiveType.Int64)
+                        .value("32767", 32767L)
+                        .value("-32767", -32767L)
+                    .column("TINYINT NOT NULL", PrimitiveType.Int64)
+                        .value("127", 127L)
+                        .value("-127", -127L)
+                    .execute();
+        }
+
+        @Test
+        public void bigintBoundaries() throws Exception {
+            typeTest()
+                    .column("BIGINT NOT NULL", PrimitiveType.Int64)
+                        .value("0", 0L)
+                        .value("9223372036854775807", Long.MAX_VALUE)
+                        .value("-9223372036854775807", -Long.MAX_VALUE)
+                    .execute();
+        }
+
+        @Test
+        public void booleanMaps() throws Exception {
+            typeTest()
+                    .column("BOOLEAN NOT NULL", PrimitiveType.Bool)
+                        .value("TRUE", true)
+                        .value("FALSE", false)
+                    .column("BOOLEAN",
+                            PrimitiveType.Bool.makeOptional())
+                        .value("TRUE", true)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void doublePrecision() throws Exception {
+            typeTest()
+                    .column("DOUBLE PRECISION NOT NULL",
+                            PrimitiveType.Double)
+                        .value("1.5", 1.5d)
+                        .value("-0.25", -0.25d)
+                    .column("FLOAT NOT NULL", PrimitiveType.Double)
+                        .value("3.14", 3.14d)
+                        .value("2.71", 2.71d)
+                    .column("DOUBLE PRECISION",
+                            PrimitiveType.Double.makeOptional())
+                        .value("9.99", 9.99d)
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void realMapsToDouble() throws Exception {
+            typeTest()
+                    .column("REAL NOT NULL", PrimitiveType.Double)
+                        .value("1.5", 1.5d)
+                        .value("1e100", 1e100d)
+                    .execute();
+        }
+
+        @Test
+        public void stringTypesMapToText() throws Exception {
+            typeTest()
+                    .column("VARCHAR(100) NOT NULL", PrimitiveType.Text)
+                        .value("'hello'", "hello")
+                        .value("''", "")
+                        .value("'кириллица'", "кириллица")
+                    .column("LONG VARCHAR NOT NULL", PrimitiveType.Text)
+                        .value("'long text'", "long text")
+                        .value("'second'", "second")
+                        .value("'third'", "third")
+                    .column("VARCHAR(100)",
+                            PrimitiveType.Text.makeOptional())
+                        .value("'hello'", "hello")
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void charPreservesTrailingSpaces() throws Exception {
+            typeTest()
+                    .column("CHAR(10) NOT NULL", PrimitiveType.Text)
+                        .value("'hello'", "hello     ")
+                    .execute();
+        }
+
+        @Test
+        public void varbinaryMapsToBytes() throws Exception {
+            typeTest()
+                    .column("VARBINARY(100) NOT NULL",
+                            PrimitiveType.Bytes)
+                        .value("HEX_TO_BINARY('0xDEADBEEF')",
+                                new byte[]{(byte) 0xDE, (byte) 0xAD,
+                                           (byte) 0xBE, (byte) 0xEF})
+                        .value("HEX_TO_BINARY('0x00')",
+                                new byte[]{(byte) 0x00})
+                    .execute();
+        }
+
+        @Test
+        public void scaledDecimalMapsToDecimal() throws Exception {
+            typeTest()
+                    .column("NUMERIC(10, 4) NOT NULL",
+                            DecimalType.of(10, 4))
+                        .value("123.4567", new BigDecimal("123.4567"))
+                        .value("-999999.9999",
+                                new BigDecimal("-999999.9999"))
+                        .value("0", new BigDecimal("0.0000"))
+                    .column("NUMERIC(10, 2)",
+                            DecimalType.of(10, 2).makeOptional())
+                        .value("99.99", new BigDecimal("99.99"))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void zeroScaleDecimalMapsToInt32() throws Exception {
+            typeTest()
+                    .column("NUMERIC(5, 0) NOT NULL",
+                            PrimitiveType.Int32)
+                        .value("12345", 12345)
+                        .value("-99999", -99999)
+                    .execute();
+        }
+
+        @Test
+        public void zeroScaleDecimalMapsToInt64() throws Exception {
+            typeTest()
+                    .column("NUMERIC(15, 0) NOT NULL",
+                            PrimitiveType.Int64)
+                        .value("999999999999999", 999999999999999L)
+                        .value("-999999999999999", -999999999999999L)
+                    .execute();
+        }
+
+        @Test
+        public void highPrecisionDecimalMapsToDecimal() throws Exception {
+            typeTest()
+                    .column("NUMERIC(25, 0) NOT NULL",
+                            DecimalType.of(35, 0))
+                        .value("1234567890123456789012345",
+                                new BigDecimal(
+                                        "1234567890123456789012345"))
+                    .execute();
+        }
+
+        @Test
+        public void decimalAliasesMapToNumeric() throws Exception {
+            typeTest()
+                    .column("DECIMAL(10, 2) NOT NULL",
+                            DecimalType.of(10, 2))
+                        .value("123.45", new BigDecimal("123.45"))
+                    .column("NUMBER(10, 2) NOT NULL",
+                            DecimalType.of(10, 2))
+                        .value("67.89", new BigDecimal("67.89"))
+                    .column("MONEY NOT NULL",
+                            DecimalType.of(18, 4))
+                        .value("99.99", new BigDecimal("99.9900"))
+                    .execute();
+        }
+
+        @Test
+        public void defaultDecimalTypeWhenCustomDisabled()
+                throws Exception {
+            typeTest()
+                    .withOptions(
+                            opts -> opts.setAllowCustomDecimal(false))
+                    .column("NUMERIC(10, 4) NOT NULL",
+                            DecimalType.getDefault())
+                        .value("123.4567",
+                                new BigDecimal("123.4567"))
+                    .execute();
+        }
+
+        @Test
+        public void dateType() throws Exception {
+            typeTest()
+                    .column("DATE NOT NULL", PrimitiveType.Date32)
+                        .value("'1970-01-01'",
+                                LocalDate.of(1970, 1, 1))
+                        .value("'2024-01-15'",
+                                LocalDate.of(2024, 1, 15))
+                    .column("DATE",
+                            PrimitiveType.Date32.makeOptional())
+                        .value("'2024-01-15'",
+                                LocalDate.of(2024, 1, 15))
+                        .value("NULL", null)
+                    .execute();
+        }
+
+        @Test
+        public void dateAsInt() throws Exception {
+            typeTest()
+                    .withOptions(
+                            opts -> opts.setDateConv(DateConv.INT))
+                    .column("DATE NOT NULL", PrimitiveType.Int32)
+                        .value("'1970-01-01'", 19700101)
+                        .value("'2024-01-15'", 20240115)
+                    .execute();
+        }
+
+        @Test
+        public void dateAsText() throws Exception {
+            typeTest()
+                    .withOptions(
+                            opts -> opts.setDateConv(DateConv.STR))
+                    .column("DATE NOT NULL", PrimitiveType.Text)
+                        .value("'1970-01-01'", "1970/01/01")
+                        .value("'2024-01-15'", "2024/01/15")
+                    .execute();
+        }
+
+        @Test
+        public void timestampMapsToTimestamp64() throws Exception {
+            typeTest()
+                    .column("TIMESTAMP NOT NULL",
+                            PrimitiveType.Timestamp64)
+                        .value("'2024-01-15 10:30:45'",
+                                Instant.parse(
+                                        "2024-01-15T10:30:45Z"))
+                        .value("'2024-01-15 10:30:45.123456'",
+                                Instant.parse(
+                                    "2024-01-15T10:30:45.123456Z"))
+                    .execute();
+        }
+
+        @Test
+        public void timestampWithTimeZone() throws Exception {
+            typeTest()
+                    .column("TIMESTAMPTZ NOT NULL",
+                            PrimitiveType.Timestamp64)
+                        .value("'2024-01-15 10:30:45+00'::TIMESTAMPTZ",
+                                Instant.parse(
+                                        "2024-01-15T10:30:45Z"))
+                        .value("'2024-06-20 15:00:00+03'::TIMESTAMPTZ",
+                                Instant.parse(
+                                        "2024-06-20T12:00:00Z"))
+                    .execute();
+        }
+
+        @Test
+        public void timeMapsToInt32() throws Exception {
+            typeTest()
+                    .column("TIME NOT NULL", PrimitiveType.Int32)
+                        .value("'00:00:00'", 0)
+                        .value("'10:30:45'", 37845)
+                        .value("'23:59:59'", 86399)
+                    .execute();
+        }
+    }
+
+    @Nested class TypeTestsRow extends VerticaTypeCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TypeTestsArrow extends VerticaTypeCases {
+        @Override public boolean useArrow() { return true; }
+    }
+
+    abstract class VerticaTableCases
+            extends AbstractYdbImporterTableTest {
+
+        public abstract boolean useArrow();
+
+        @Override
+        public SourceDb sourceDb() {
+            return new SourceDb(verticaContainer, SourceType.VERTICA, "public");
+        }
+
+        @Override
+        protected String smallBlob(byte[] data) {
+            return "HEX_TO_BINARY('" + hex(data) + "')";
+        }
+
+        @Override
+        protected String bigBlob(String hexPair, int count) {
+            byte[] data = filled(count, (byte) Integer.parseInt(hexPair, 16));
+            return "HEX_TO_BINARY('" + hex(data) + "')";
+        }
+
+        /*
+         * Vertica specific: ENABLED constraints become PK,
+         * advisory (not enabled) fall back to synthetic key.
+         */
+        @Test
+        public void primaryKeySelection() throws Exception {
+            importTogether()
+                    
+                    .add(tableTest("public", "pk_enforced")
+                            .setupSql(
+                                "CREATE TABLE public.pk_enforced ("
+                                + "  id INT NOT NULL,"
+                                + "  name VARCHAR(50) NOT NULL,"
+                                + "  CONSTRAINT pk_enf PRIMARY KEY (id) ENABLED"
+                                + ");"
+                                + "INSERT INTO public.pk_enforced VALUES (1,'a');"
+                                + "INSERT INTO public.pk_enforced VALUES (2,'b')")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + "public.pk_enforced CASCADE")
+                            .expectPrimaryKey("id")
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1L, "name", "a"))
+                    .add(tableTest("public", "pk_advisory")
+                            .setupSql(
+                                "CREATE TABLE public.pk_advisory ("
+                                + "  id INT NOT NULL,"
+                                + "  name VARCHAR(50) NOT NULL,"
+                                + "  PRIMARY KEY (id)"
+                                + ");"
+                                + "INSERT INTO public.pk_advisory VALUES (1,'a');"
+                                + "INSERT INTO public.pk_advisory VALUES (2,'b')")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + "public.pk_advisory CASCADE")
+                            .expectSyntheticKey()
+                            .expectRowCount(2)
+                            .expectRowExists("id", 1L, "name", "a"))
+                    .add(tableTest("public", "uq_enabled")
+                            .setupSql(
+                                "CREATE TABLE public.uq_enabled ("
+                                + "  code VARCHAR(20) NOT NULL,"
+                                + "  value INT NOT NULL,"
+                                + "  CONSTRAINT uq_c UNIQUE (code) ENABLED"
+                                + ");"
+                                + "INSERT INTO public.uq_enabled VALUES ('A',10);"
+                                + "INSERT INTO public.uq_enabled VALUES ('B',20)")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + "public.uq_enabled CASCADE")
+                            .expectPrimaryKey("code")
+                            .expectRowCount(2)
+                            .expectRowExists("code", "A", "value", 10L))
+                    .add(tableTest("public", "uq_fewer_cols")
+                            .setupSql(
+                                "CREATE TABLE public.uq_fewer_cols ("
+                                + "  a BIGINT NOT NULL,"
+                                + "  b VARCHAR(10) NOT NULL,"
+                                + "  c VARCHAR(10) NOT NULL,"
+                                + "  CONSTRAINT uq_ab UNIQUE (a, b) ENABLED,"
+                                + "  CONSTRAINT uq_c UNIQUE (c) ENABLED"
+                                + ");"
+                                + "INSERT INTO public.uq_fewer_cols VALUES (1,'x','p');"
+                                + "INSERT INTO public.uq_fewer_cols VALUES (2,'y','q')")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + "public.uq_fewer_cols CASCADE")
+                            .expectPrimaryKey("c")
+                            .expectRowCount(2)
+                            .expectRowExists("c", "p"))
+                    .add(tableTest("public", "uq_sorted_names")
+                            .setupSql(
+                                "CREATE TABLE public.uq_sorted_names ("
+                                + "  x BIGINT NOT NULL,"
+                                + "  a VARCHAR(10) NOT NULL,"
+                                + "  b VARCHAR(10) NOT NULL,"
+                                + "  z VARCHAR(10) NOT NULL,"
+                                + "  CONSTRAINT uq_za UNIQUE (z, a) ENABLED,"
+                                + "  CONSTRAINT uq_ab UNIQUE (a, b) ENABLED"
+                                + ");"
+                                + "INSERT INTO public.uq_sorted_names VALUES (1,'v1','v2','v3');"
+                                + "INSERT INTO public.uq_sorted_names VALUES (2,'v4','v5','v6')")
+                            .cleanupSql("DROP TABLE IF EXISTS "
+                                    + "public.uq_sorted_names CASCADE")
+                            .expectPrimaryKey("a", "b")
+                            .expectRowCount(2)
+                            .expectRowExists("a", "v1", "b", "v2"))
+                    .run();
+        }
+
+        @Test
+        public void partitionedImport() throws Exception {
+            tableTest("public", "part_sales")
+                    
+                    .setupSql(
+                        "CREATE TABLE public.part_sales ("
+                        + "sale_id INT NOT NULL,"
+                        + "region_id INT NOT NULL,"
+                        + "amount INT NOT NULL,"
+                        + "CONSTRAINT pk_ps PRIMARY KEY (sale_id) ENABLED"
+                        + ") PARTITION BY region_id;"
+                        + "INSERT INTO public.part_sales VALUES"
+                        + " (1, 1, 100);"
+                        + "INSERT INTO public.part_sales VALUES"
+                        + " (2, 2, 200);"
+                        + "INSERT INTO public.part_sales VALUES"
+                        + " (3, 3, 300)")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.part_sales CASCADE")
+                    .expectPrimaryKey("sale_id")
+                    .expectRowCount(3)
+                    .expectRowExists("sale_id", 1L, "amount", 100L)
+                    .expectRowExists("sale_id", 3L, "amount", 300L)
+                    .run();
+        }
+
+        @Test
+        public void emptyTableCreatesSchema() throws Exception {
+            tableTest("public", "empty_tbl")
+                    
+                    .setupSql(
+                        "CREATE TABLE public.empty_tbl ("
+                        + "id INT NOT NULL,"
+                        + "name VARCHAR(50) NOT NULL,"
+                        + "CONSTRAINT pk_empty PRIMARY KEY (id) ENABLED"
+                        + ")")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.empty_tbl CASCADE")
+                    .expectPrimaryKey("id")
+                    .expectRowCount(0)
+                    .run();
+        }
+
+        @Test
+        public void customQueryTextImport() throws Exception {
+            tableTest("public", "query_src")
+                    
+                    .setupSql(
+                        "CREATE TABLE public.query_src ("
+                        + "id INT NOT NULL,"
+                        + "val VARCHAR(50) NOT NULL,"
+                        + "CONSTRAINT pk_qs PRIMARY KEY (id) ENABLED"
+                        + ");"
+                        + "INSERT INTO public.query_src VALUES"
+                        + " (1, 'a');"
+                        + "INSERT INTO public.query_src VALUES"
+                        + " (2, 'b');"
+                        + "INSERT INTO public.query_src VALUES"
+                        + " (3, 'c');"
+                        + "INSERT INTO public.query_src VALUES"
+                        + " (4, 'd')")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.query_src CASCADE")
+                    .queryText("SELECT id, val FROM public.query_src"
+                            + " WHERE id <= 2")
+                    .expectSyntheticKey()
+                    .expectRowCount(2)
+                    .expectRowExists("id", 1L, "val", "a")
+                    .expectRowExists("id", 2L, "val", "b")
+                    .run();
+        }
+
+        @Test
+        public void syntheticKeyDistinguishesRows() throws Exception {
+            tableTest("public", "synth_tbl")
+                    
+                    .setupSql(
+                        "CREATE TABLE public.synth_tbl ("
+                        + "seq INT NOT NULL,"
+                        + "name VARCHAR(50) NOT NULL"
+                        + ");"
+                        + "INSERT INTO public.synth_tbl VALUES"
+                        + " (1, 'same');"
+                        + "INSERT INTO public.synth_tbl VALUES"
+                        + " (2, 'same');"
+                        + "INSERT INTO public.synth_tbl VALUES"
+                        + " (3, 'same')")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.synth_tbl CASCADE")
+                    .expectSyntheticKey()
+                    .expectRowCount(3)
+                    .expectRowExists("seq", 1L, "name", "same")
+                    .expectRowExists("seq", 2L, "name", "same")
+                    .expectRowExists("seq", 3L, "name", "same")
+                    .run();
+        }
+
+        @Test
+        public void skipUnsupportedColumns() throws Exception {
+            // UUID -> Types.OTHER, INTERVAL -> Types.OTHER
+            tableTest("public", "skip_vertica")
+                    
+                    .withOptions(opts -> opts.setSkipUnknownTypes(true))
+                    .setupSql(
+                        "CREATE TABLE public.skip_vertica ("
+                        + "id INT NOT NULL,"
+                        + "name VARCHAR(50) NOT NULL,"
+                        + "uid UUID,"
+                        + "period INTERVAL DAY TO SECOND,"
+                        + "CONSTRAINT pk_skip PRIMARY KEY (id) ENABLED"
+                        + ");"
+                        + "INSERT INTO public.skip_vertica VALUES"
+                        + " (1, 'a', '01234567-89ab-cdef-0123-456789abcdef',"
+                        + "  INTERVAL '1 12:00:00' DAY TO SECOND);"
+                        + "INSERT INTO public.skip_vertica VALUES"
+                        + " (2, 'b', '11234567-89ab-cdef-0123-456789abcdef',"
+                        + "  INTERVAL '2 00:00:00' DAY TO SECOND)")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.skip_vertica CASCADE")
+                    .expectPrimaryKey("id")
+                    .expectSkippedColumns("uid", "period")
+                    .expectRowCount(2)
+                    .expectRowExists("id", 1L, "name", "a")
+                    .run();
+        }
+
+        @Test
+        public void partitionedMultiBlobSynthKey() throws Exception {
+            byte[] thumb1 = "thumb-1".getBytes();
+            byte[] thumb2 = "thumb-2".getBytes();
+            byte[] thumb3 = "thumb-3".getBytes();
+            byte[] thumb4 = "thumb-4".getBytes();
+
+            byte[] full1 = filled(524_288, (byte) 0x11);
+            byte[] full2 = filled(524_288, (byte) 0x22);
+            byte[] full3 = filled(524_288, (byte) 0x33);
+            byte[] full4 = filled(524_288, (byte) 0x44);
+
+            String insertSql =
+                    "INSERT INTO public.mega_blob VALUES (?, ?, ?, ?)";
+            tableTest("public", "mega_blob")
+
+                    .setupSql(
+                        "CREATE TABLE public.mega_blob ("
+                        + "  region_id INT NOT NULL,"
+                        + "  label VARCHAR(30),"
+                        + "  thumbnail LONG VARBINARY,"
+                        + "  fullsize LONG VARBINARY"
+                        + ") PARTITION BY region_id")
+                    .insertRow(insertSql, 1, "book-1", thumb1, full1)
+                    .insertRow(insertSql, 1, "book-2", thumb2, full2)
+                    .insertRow(insertSql, 1, "null-row", null, null)
+                    .insertRow(insertSql, 2, "book-3", thumb3, full3)
+                    .insertRow(insertSql, 2, "book-4", thumb4, full4)
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.mega_blob CASCADE")
+                    .expectSyntheticKey()
+                    .expectRowCount(5)
+                    .expectBlobColumn("thumbnail")
+                    .expectBlobColumn("fullsize")
+                    .expectBlobBytes("thumbnail", "label", "book-1", thumb1)
+                    .expectBlobBytes("thumbnail", "label", "book-2", thumb2)
+                    .expectBlobBytes("thumbnail", "label", "null-row", null)
+                    .expectBlobBytes("thumbnail", "label", "book-3", thumb3)
+                    .expectBlobBytes("thumbnail", "label", "book-4", thumb4)
+                    .expectBlobBytes("fullsize", "label", "book-1", full1)
+                    .expectBlobBytes("fullsize", "label", "book-2", full2)
+                    .expectBlobBytes("fullsize", "label", "null-row", null)
+                    .expectBlobBytes("fullsize", "label", "book-3", full3)
+                    .expectBlobBytes("fullsize", "label", "book-4", full4)
+                    .run();
+
+            tableTest("public", "small_blob")
+
+                    .setupSql(
+                        "CREATE TABLE public.small_blob ("
+                        + "  id INT NOT NULL,"
+                        + "  name VARCHAR(50) NOT NULL,"
+                        + "  data LONG VARBINARY,"
+                        + "  CONSTRAINT pk_sb PRIMARY KEY (id) ENABLED"
+                        + ");"
+                        + "INSERT INTO public.small_blob VALUES (1, 'hello', "
+                        + smallBlob("Hello".getBytes()) + ");"
+                        + "INSERT INTO public.small_blob VALUES (2, 'null_blob', NULL);"
+                        + "INSERT INTO public.small_blob VALUES (3, 'world', "
+                        + smallBlob("World".getBytes()) + ")")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.small_blob CASCADE")
+                    .expectPrimaryKey("id")
+                    .expectRowCount(3)
+                    .expectBlobColumn("data")
+                    .expectBlobBytes("data", "id", 1, "Hello".getBytes())
+                    .expectBlobBytes("data", "id", 3, "World".getBytes())
+                    .expectBlobBytes("data", "id", 2, null)
+                    .run();
+        }
+
+        @Test
+        public void clobContentImport() throws Exception {
+            String bigText = repeat("Y", 524_288);
+            String insertSql =
+                    "INSERT INTO public.clob_docs VALUES (?, ?, ?)";
+
+            tableTest("public", "clob_docs")
+                    .setupSql(
+                        "CREATE TABLE public.clob_docs ("
+                        + "  id    INT NOT NULL,"
+                        + "  short LONG VARCHAR,"
+                        + "  large LONG VARCHAR,"
+                        + "  CONSTRAINT pk_cd PRIMARY KEY (id) ENABLED"
+                        + ")")
+                    .insertRow(insertSql, 1, "YDB", bigText)
+                    .insertRow(insertSql, 2, null, null)
+                    .insertRow(insertSql, 3, "", "")
+                    .cleanupSql("DROP TABLE IF EXISTS "
+                            + "public.clob_docs CASCADE")
+                    .clobColumns("short", "large")
+                    .expectPrimaryKey("id")
+                    .expectRowCount(3)
+                    .expectClobColumn("short")
+                    .expectClobColumn("large")
+                    .expectClobContent("short", "id", 1, "YDB")
+                    .expectClobContent("large", "id", 1, bigText)
+                    .expectClobContent("short", "id", 2, null)
+                    .expectClobContent("large", "id", 2, null)
+                    .expectClobContent("short", "id", 3, "")
+                    .expectClobContent("large", "id", 3, "")
+                    .run();
+        }
+    }
+
+    @Nested class TableTestsRow extends VerticaTableCases {
+        @Override public boolean useArrow() { return false; }
+    }
+
+    @Nested class TableTestsArrow extends VerticaTableCases {
+        @Override public boolean useArrow() { return true; }
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/typetest/AbstractYdbImporterTypeTest.java
+++ b/src/test/java/tech/ydb/importer/integration/typetest/AbstractYdbImporterTypeTest.java
@@ -9,6 +9,10 @@ public abstract class AbstractYdbImporterTypeTest extends AbstractYdbImporterInt
         return "";
     }
 
+    protected String dropTableSql(String qualifiedTable) {
+        return "DROP TABLE IF EXISTS " + qualifiedTable;
+    }
+
     protected TypeTestBuilder typeTest() {
         return new TypeTestBuilder(this);
     }

--- a/src/test/java/tech/ydb/importer/integration/typetest/TypeTestBuilder.java
+++ b/src/test/java/tech/ydb/importer/integration/typetest/TypeTestBuilder.java
@@ -235,8 +235,8 @@ public final class TypeTestBuilder {
     private void cleanupSource(String tableName) {
         try (Connection con = test.openSourceConnection();
              Statement st = con.createStatement()) {
-            st.execute("DROP TABLE IF EXISTS "
-                    + quoteId(test.schemaName()) + "." + quoteId(tableName));
+            st.execute(test.dropTableSql(
+                    quoteId(test.schemaName()) + "." + quoteId(tableName)));
         } catch (Exception ex) {
             LOG.warn("Failed to drop source table {}.{}",
                     test.schemaName(), tableName, ex);

--- a/src/test/java/tech/ydb/importer/integration/verification/ColumnSpec.java
+++ b/src/test/java/tech/ydb/importer/integration/verification/ColumnSpec.java
@@ -4,10 +4,16 @@ public final class ColumnSpec {
 
     private final String name;
     private final LogicalType type;
+    private final boolean nullable;
 
     public ColumnSpec(String name, LogicalType type) {
+        this(name, type, false);
+    }
+
+    public ColumnSpec(String name, LogicalType type, boolean nullable) {
         this.name = name;
         this.type = type;
+        this.nullable = nullable;
     }
 
     public String name() {
@@ -16,5 +22,9 @@ public final class ColumnSpec {
 
     public LogicalType type() {
         return type;
+    }
+
+    public boolean nullable() {
+        return nullable;
     }
 }

--- a/src/test/java/tech/ydb/importer/integration/verification/DialectLoader.java
+++ b/src/test/java/tech/ydb/importer/integration/verification/DialectLoader.java
@@ -28,7 +28,7 @@ public abstract class DialectLoader {
                 ddl.append(", ");
             }
             ddl.append(cols.get(i).name()).append(' ')
-                    .append(toDdl(cols.get(i).type()));
+                    .append(columnDdl(cols.get(i)));
         }
         if (scenario.blobColumn() != null) {
             String blobType = blobDdlType();
@@ -139,10 +139,9 @@ public abstract class DialectLoader {
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     protected LocalDateTime[] rangeDateBoundaries(TableScenario scenario) {
-        long n = scenario.oracle().rowCount();
         int p = partitionCount(scenario);
         LocalDateTime[] b = new LocalDateTime[p - 1];
-        long chunkSeconds = Math.max(1L, n / p);
+        long chunkSeconds = Math.max(1L, ShopScenarios.TARGET_SECONDS / p);
         for (int i = 0; i < p - 1; i++) {
             b[i] = ShopScenarios.BASE_DT.plusSeconds((i + 1) * chunkSeconds);
         }
@@ -150,6 +149,10 @@ public abstract class DialectLoader {
     }
 
     protected abstract String toDdl(LogicalType type);
+
+    protected String columnDdl(ColumnSpec col) {
+        return toDdl(col.type());
+    }
 
     protected String blobDdlType() {
         return null;

--- a/src/test/java/tech/ydb/importer/integration/verification/Scenario.java
+++ b/src/test/java/tech/ydb/importer/integration/verification/Scenario.java
@@ -39,7 +39,12 @@ public final class Scenario {
         }
 
         public Builder col(String name, LogicalType type, LongFunction<Object> fn) {
-            defs.add(new ColumnDef(name, type, fn));
+            defs.add(new ColumnDef(name, type, fn, false));
+            return this;
+        }
+
+        public Builder colNullable(String name, LogicalType type, LongFunction<Object> fn) {
+            defs.add(new ColumnDef(name, type, fn, true));
             return this;
         }
 
@@ -58,7 +63,7 @@ public final class Scenario {
         public TableScenario build() {
             List<ColumnSpec> columns = new ArrayList<>(defs.size());
             for (ColumnDef d : defs) {
-                columns.add(new ColumnSpec(d.name, d.type));
+                columns.add(new ColumnSpec(d.name, d.type, d.nullable));
             }
             RowOracle oracle = new RowOracle() {
                 @Override
@@ -89,11 +94,14 @@ public final class Scenario {
         final String name;
         final LogicalType type;
         final LongFunction<Object> fn;
+        final boolean nullable;
 
-        ColumnDef(String name, LogicalType type, LongFunction<Object> fn) {
+        ColumnDef(String name, LogicalType type, LongFunction<Object> fn,
+                  boolean nullable) {
             this.name = name;
             this.type = type;
             this.fn = fn;
+            this.nullable = nullable;
         }
     }
 }

--- a/src/test/java/tech/ydb/importer/integration/verification/ScenarioRandom.java
+++ b/src/test/java/tech/ydb/importer/integration/verification/ScenarioRandom.java
@@ -1,0 +1,70 @@
+package tech.ydb.importer.integration.verification;
+
+/**
+ * Helpers that turn an id into a stable value.
+ * The same id always gives the same result.
+ */
+public final class ScenarioRandom {
+
+    private ScenarioRandom() {
+    }
+
+    /** A salt for a column, taken from its name. */
+    public static long salt(String name) {
+        long h = stableHash(name.length());
+        for (int i = 0; i < name.length(); i++) {
+            h = stableHash(h ^ name.charAt(i));
+        }
+        return h;
+    }
+
+    /** Spreads sequential ids evenly across the range. */
+    public static long stableHash(long id) {
+        long h = id;
+        h ^= h >>> 33;
+        h *= 0xff51afd7ed558ccdL;
+        h ^= h >>> 33;
+        h *= 0xc4ceb9fe1a85ec53L;
+        h ^= h >>> 33;
+        return h;
+    }
+
+    /** Different columns of the same row stay independent. */
+    public static long stableHash(long id, long salt) {
+        return stableHash(id ^ salt);
+    }
+
+    public static double uniform(long id, long salt) {
+        long bits = stableHash(id, salt) & 0x3FFFFFFFL;
+        return (bits + 1.0) / (1L << 30);
+    }
+
+    /** Picks a number from 1 to n, smaller ones more often. */
+    public static long zipfLikePick(long id, long n, double alpha, long salt) {
+        if (n <= 1) {
+            return 1L;
+        }
+        return 1L + (long) ((n - 1) * Math.pow(uniform(id, salt), alpha));
+    }
+
+    public static <T> T weighted(long id, T[] values, int[] weights, long salt) {
+        int total = 0;
+        for (int w : weights) {
+            total += w;
+        }
+        int x = (int) Math.floorMod(stableHash(id, salt), total);
+        int acc = 0;
+        for (int i = 0; i < values.length; i++) {
+            acc += weights[i];
+            if (x < acc) {
+                return values[i];
+            }
+        }
+        return values[values.length - 1];
+    }
+
+    public static <T> T pickFromArray(long id, T[] dict, long salt) {
+        int idx = (int) Math.floorMod(stableHash(id, salt), dict.length);
+        return dict[idx];
+    }
+}

--- a/src/test/java/tech/ydb/importer/integration/verification/ShopScenarios.java
+++ b/src/test/java/tech/ydb/importer/integration/verification/ShopScenarios.java
@@ -187,9 +187,9 @@ public final class ShopScenarios {
                 .col("is_verified",     BOOL,     id -> intMod(id, B_VERIFIED, 100) < 67)
                 .col("registered_date", DATE,     id ->
                         BASE_DATE.plusDays(intMod(id, T_REGISTERED, 1460)))
-                .col("bio",             STRING,   id ->
+                .colNullable("bio",     STRING,   id ->
                         oneIn(id, G_BIO, 5) ? null : "Bio of user " + id)
-                .col("deleted_at",      DATETIME, id ->
+                .colNullable("deleted_at", DATETIME, id ->
                         oneIn(id, G_DELETED, 100) ? randomTime(id, T_DELETED) : null)
                 .build();
     }
@@ -313,7 +313,7 @@ public final class ShopScenarios {
                 .col("address_id",    INT64,    id ->
                         zipfLikePick(id, addressCount, ZIPF_ALPHA, FK_ADDRESS))
                 .col("shipped_at",    DATETIME, id -> randomTime(id, T_SHIPPED))
-                .col("tracking_code", STRING,   id ->
+                .colNullable("tracking_code", STRING,   id ->
                         oneIn(id, G_TRACKING, 4) ? null : "TRK-" + id)
                 .partition(PartitionStyle.HASH_INT, "address_id")
                 .build();

--- a/src/test/java/tech/ydb/importer/integration/verification/ShopScenarios.java
+++ b/src/test/java/tech/ydb/importer/integration/verification/ShopScenarios.java
@@ -16,6 +16,11 @@ import static tech.ydb.importer.integration.verification.LogicalType.DECIMAL_18_
 import static tech.ydb.importer.integration.verification.LogicalType.INT32;
 import static tech.ydb.importer.integration.verification.LogicalType.INT64;
 import static tech.ydb.importer.integration.verification.LogicalType.STRING;
+import static tech.ydb.importer.integration.verification.ScenarioRandom.pickFromArray;
+import static tech.ydb.importer.integration.verification.ScenarioRandom.salt;
+import static tech.ydb.importer.integration.verification.ScenarioRandom.stableHash;
+import static tech.ydb.importer.integration.verification.ScenarioRandom.weighted;
+import static tech.ydb.importer.integration.verification.ScenarioRandom.zipfLikePick;
 
 /** Shop scenarios for cross-DB verification */
 public final class ShopScenarios {
@@ -23,25 +28,169 @@ public final class ShopScenarios {
     private static final LocalDate BASE_DATE = LocalDate.of(2020, 1, 1);
     static final LocalDateTime BASE_DT =
             LocalDateTime.of(2024, 1, 1, 0, 0, 0);
-    private static final String[] CURRENCIES = {"USD", "EUR", "RUB"};
+
+    /** Time range for generated timestamps (2 years). */
+    static final long TARGET_SECONDS = 2L * 365L * 86400L;
+
+    private static final double ZIPF_ALPHA = 2.0;
+
+    private static final long BLOB_ROW_COUNT = 1000;
+
+    // Separate salt per column for independent values.
+    private static final long FK_USER       = salt("fk_user");
+    private static final long FK_PRODUCT    = salt("fk_product");
+    private static final long FK_ORDER      = salt("fk_order");
+    private static final long FK_ADDRESS    = salt("fk_address");
+    private static final long FK_CATEGORY   = salt("fk_category");
+    private static final long FK_WAREHOUSE  = salt("fk_warehouse");
+
+    private static final long T_PLACED      = salt("placed_at");
+    private static final long T_PAID        = salt("paid_at");
+    private static final long T_SHIPPED     = salt("shipped_at");
+    private static final long T_REVIEWED    = salt("reviewed_at");
+    private static final long T_UPDATE      = salt("updated_at");
+    private static final long T_TS          = salt("ts");
+    private static final long T_DELETED     = salt("deleted_at");
+    private static final long T_REGISTERED  = salt("registered_date");
+
+    private static final long CAT_METHOD    = salt("method");
+    private static final long CAT_CURRENCY  = salt("currency");
+    private static final long CAT_STATUS    = salt("status");
+    private static final long CAT_EVENT     = salt("action_type");
+    private static final long CAT_ENTITY    = salt("entity_type");
+
+    private static final long TXT_CITY        = salt("city");
+    private static final long TXT_STREET_PFX  = salt("street_prefix");
+    private static final long TXT_STREET_ROOT = salt("street_root");
+    private static final long TXT_FIRST       = salt("first_name");
+    private static final long TXT_LAST        = salt("last_name");
+    private static final long TXT_HOUSE       = salt("house");
+
+    private static final long B_VERIFIED    = salt("is_verified");
+    private static final long B_AVAILABLE   = salt("is_available");
+    private static final long B_DEFAULT     = salt("is_default");
+
+    private static final long G_DELETED     = salt("deleted_gate");
+    private static final long G_BIO         = salt("bio_gate");
+    private static final long G_TRACKING    = salt("tracking_gate");
+
+    private static final long N_WEIGHT      = salt("weight_grams");
+    private static final long N_QUANTITY    = salt("quantity");
+    private static final long N_QTY         = salt("qty");
+    private static final long N_RATING      = salt("rating");
+    private static final long N_POSTAL      = salt("postal_code");
+
+    // Category values and their weights.
     private static final String[] METHODS = {"card", "cash", "transfer", "crypto"};
+    private static final int[] METHODS_W = {70, 20, 8, 2};
+
+    private static final String[] CURRENCIES = {"USD", "EUR", "RUB"};
+    private static final int[] CURRENCIES_W = {60, 25, 15};
+
+    private static final String[] STATUSES = {"new", "paid", "shipped", "done"};
+    private static final int[] STATUSES_W = {10, 25, 25, 40};
+
     private static final String[] EVENT_TYPES =
             {"view", "click", "purchase", "logout", "error"};
+    private static final int[] EVENT_W = {80, 10, 5, 3, 2};
+
     private static final String[] ENTITY_TYPES =
             {"user", "order", "product", "payment", "shipment"};
-    private static final long BLOB_ROW_COUNT = 1000;
+    private static final int[] ENTITY_W = {20, 30, 30, 10, 10};
+
+    // Value dictionaries for text columns.
+    private static final String[] CITIES = {
+        "Москва", "Санкт-Петербург", "Новосибирск", "Екатеринбург", "Казань",
+        "Нижний Новгород", "Челябинск", "Самара", "Омск", "Ростов-на-Дону",
+        "Уфа", "Красноярск", "Воронеж", "Пермь", "Волгоград",
+        "Краснодар", "Саратов", "Тюмень", "Тольятти", "Ижевск",
+        "Барнаул", "Ульяновск", "Иркутск", "Хабаровск", "Ярославль",
+        "Владивосток", "Махачкала", "Томск", "Оренбург", "Кемерово",
+        "Новокузнецк", "Рязань", "Астрахань", "Набережные Челны", "Пенза",
+        "Липецк", "Тула", "Киров", "Чебоксары", "Калининград",
+        "Брянск", "Курск", "Иваново", "Магнитогорск", "Тверь",
+        "Ставрополь", "Симферополь", "Белгород", "Архангельск", "Владимир",
+        "Сочи", "Курган", "Смоленск", "Калуга", "Чита",
+        "Орёл", "Волжский", "Череповец", "Владикавказ", "Мурманск",
+        "Сургут", "Вологда", "Тамбов", "Стерлитамак", "Грозный",
+        "Якутск", "Кострома", "Комсомольск-на-Амуре", "Петрозаводск", "Таганрог",
+        "Нижневартовск", "Йошкар-Ола", "Братск", "Новороссийск", "Дзержинск",
+        "Шахты", "Нальчик", "Орск", "Сыктывкар", "Нижнекамск"
+    };
+
+    private static final String[] STREET_PREFIXES = {
+        "ул.", "пр-т", "пер.", "наб.", "пл.", "ш.", "б-р", "пр-д", "тр.", "аллея"
+    };
+
+    private static final String[] STREET_ROOTS = {
+        "Ленина", "Гагарина", "Пушкина", "Лесная", "Садовая",
+        "Школьная", "Молодёжная", "Центральная", "Заводская", "Полевая",
+        "Северная", "Южная", "Восточная", "Западная", "Юбилейная",
+        "Советская", "Первомайская", "Октябрьская", "Кирова", "Чехова",
+        "Мира", "Победы", "Свободы", "Дружбы", "Пионерская",
+        "Цветочная", "Берёзовая", "Дубовая", "Сосновая", "Рябиновая"
+    };
+
+    private static final String[] FIRST_NAMES = {
+        "Александр", "Сергей", "Дмитрий", "Андрей", "Алексей",
+        "Максим", "Иван", "Михаил", "Артём", "Никита",
+        "Денис", "Евгений", "Антон", "Павел", "Илья",
+        "Кирилл", "Роман", "Юрий", "Владимир", "Виктор",
+        "Анна", "Мария", "Елена", "Ольга", "Наталья",
+        "Татьяна", "Светлана", "Екатерина", "Юлия", "Ирина",
+        "Дарья", "Алиса", "Полина", "Виктория", "Ксения",
+        "Анастасия", "София", "Валерия", "Маргарита", "Вероника"
+    };
+
+    private static final String[] LAST_NAMES = {
+        "Иванов", "Смирнов", "Кузнецов", "Попов", "Васильев",
+        "Петров", "Соколов", "Михайлов", "Новиков", "Фёдоров",
+        "Морозов", "Волков", "Алексеев", "Лебедев", "Семёнов",
+        "Егоров", "Павлов", "Козлов", "Степанов", "Николаев",
+        "Орлов", "Андреев", "Макаров", "Никитин", "Захаров",
+        "Зайцев", "Соловьёв", "Борисов", "Яковлев", "Григорьев"
+    };
 
     private ShopScenarios() {
     }
 
+    private static LocalDateTime randomTime(long id, long salt) {
+        long secs = Math.floorMod(stableHash(id, salt), TARGET_SECONDS);
+        return BASE_DT.plusSeconds(secs);
+    }
+
+    private static int intMod(long id, long salt, int mod) {
+        return (int) Math.floorMod(stableHash(id, salt), mod);
+    }
+
+    private static boolean oneIn(long id, long salt, int n) {
+        return Math.floorMod(stableHash(id, salt), n) == 0;
+    }
+
+    private static String makeStreet(long id) {
+        String prefix = pickFromArray(id, STREET_PREFIXES, TXT_STREET_PFX);
+        String root = pickFromArray(id, STREET_ROOTS, TXT_STREET_ROOT);
+        return prefix + " " + root + ", д. " + (intMod(id, TXT_HOUSE, 200) + 1);
+    }
+
+    private static String makeName(long id) {
+        String first = pickFromArray(id, FIRST_NAMES, TXT_FIRST);
+        String last = pickFromArray(id, LAST_NAMES, TXT_LAST);
+        return first + " " + last;
+    }
+
     public static TableScenario users(long n) {
         return Scenario.table("users", n)
-                .col("id",              INT64,           id -> id)
-                .col("email",           STRING,          id -> "user" + id + "@example.com")
-                .col("name",            STRING,          id -> "Клиент №" + id)
-                .col("is_verified",     BOOL,            id -> id % 3 != 0)
-                .col("registered_date", DATE,            id -> BASE_DATE.plusDays(id % 1460))
-                .col("bio",             STRING,          id -> id % 5 == 0 ? null : "Bio of user " + id)
+                .col("id",              INT64,    id -> id)
+                .col("email",           STRING,   id -> "user" + id + "@example.com")
+                .col("name",            STRING,   ShopScenarios::makeName)
+                .col("is_verified",     BOOL,     id -> intMod(id, B_VERIFIED, 100) < 67)
+                .col("registered_date", DATE,     id ->
+                        BASE_DATE.plusDays(intMod(id, T_REGISTERED, 1460)))
+                .col("bio",             STRING,   id ->
+                        oneIn(id, G_BIO, 5) ? null : "Bio of user " + id)
+                .col("deleted_at",      DATETIME, id ->
+                        oneIn(id, G_DELETED, 100) ? randomTime(id, T_DELETED) : null)
                 .build();
     }
 
@@ -53,52 +202,62 @@ public final class ShopScenarios {
                 .build();
     }
 
-    public static TableScenario products(long n) {
+    public static TableScenario products(long n, long categoryCount) {
         return Scenario.table("products", n)
                 .col("id",           INT64,        id -> id)
-                .col("category_id",  INT64,        id -> (id % 100) + 1)
+                .col("category_id",  INT64,        id ->
+                        zipfLikePick(id, categoryCount, ZIPF_ALPHA, FK_CATEGORY))
                 .col("title",        STRING,       id -> "Product #" + id)
-                .col("price",        DECIMAL_18_4, id -> BigDecimal.valueOf((id % 10000) * 100 + 99, 2)
-                        .setScale(4, RoundingMode.UNNECESSARY))
-                .col("weight_grams", INT32,        id -> (int) ((id * 37) % 50000))
-                .col("is_available", BOOL,         id -> id % 7 != 0)
+                .col("price",        DECIMAL_18_4, id ->
+                        BigDecimal.valueOf((id % 10000) * 100 + 99, 2)
+                                .setScale(4, RoundingMode.UNNECESSARY))
+                .col("weight_grams", INT32,        id -> intMod(id, N_WEIGHT, 50000))
+                .col("is_available", BOOL,         id -> !oneIn(id, B_AVAILABLE, 7))
+                .partition(PartitionStyle.HASH_INT, "weight_grams")
                 .build();
     }
 
-    public static TableScenario inventory(long n) {
+    public static TableScenario inventory(long n, long productCount) {
         final long warehouseCount = Math.max(50L, n / 1000L);
         return Scenario.table("inventory", n)
                 .col("id",           INT64,    id -> id)
-                .col("product_id",   INT64,    id -> (id % n) + 1)
-                .col("warehouse_id", INT32,    id -> (int) (id % warehouseCount))
-                .col("quantity",     INT32,    id -> (int) ((id * 13) % 10000))
-                .col("updated_at",   DATETIME, id -> BASE_DT.plusSeconds(id))
+                .col("product_id",   INT64,    id ->
+                        zipfLikePick(id, productCount, ZIPF_ALPHA, FK_PRODUCT))
+                .col("warehouse_id", INT32,    id -> intMod(id, FK_WAREHOUSE, (int) warehouseCount))
+                .col("quantity",     INT32,    id -> intMod(id, N_QUANTITY, 10000))
+                .col("updated_at",   DATETIME, id -> randomTime(id, T_UPDATE))
                 .partition(PartitionStyle.HASH_INT, "warehouse_id")
                 .build();
     }
 
     public static TableScenario orders(long n, long userCount) {
-        final String[] statuses = {"new", "paid", "shipped", "done"};
         return Scenario.table("orders", n)
                 .col("id",        INT64,        id -> id)
-                .col("user_id",   INT64,        id -> (id % userCount) + 1)
-                .col("total",     DECIMAL_18_4, id -> BigDecimal.valueOf(id * 13, 2)
-                        .setScale(4, RoundingMode.UNNECESSARY))
-                .col("currency",  STRING,       id -> CURRENCIES[(int) (id % 3)])
-                .col("placed_at", DATETIME,     id -> BASE_DT.plusSeconds(id))
-                .col("status",    STRING,       id -> statuses[(int) (id % 4)])
+                .col("user_id",   INT64,        id ->
+                        zipfLikePick(id, userCount, ZIPF_ALPHA, FK_USER))
+                .col("total",     DECIMAL_18_4, id ->
+                        BigDecimal.valueOf(id * 13, 2)
+                                .setScale(4, RoundingMode.UNNECESSARY))
+                .col("currency",  STRING,       id ->
+                        weighted(id, CURRENCIES, CURRENCIES_W, CAT_CURRENCY))
+                .col("placed_at", DATETIME,     id -> randomTime(id, T_PLACED))
+                .col("status",    STRING,       id ->
+                        weighted(id, STATUSES, STATUSES_W, CAT_STATUS))
                 .partition(PartitionStyle.RANGE_DATE, "placed_at")
                 .build();
     }
 
-    public static TableScenario orderItems(long n, long orderCount) {
+    public static TableScenario orderItems(long n, long orderCount, long productCount) {
         return Scenario.table("order_items", n)
                 .col("id",         INT64,        id -> id)
-                .col("order_id",   INT64,        id -> (id % orderCount) + 1)
-                .col("product_id", INT64,        id -> (id * 7 % n) + 1)
-                .col("qty",        INT32,        id -> (int) ((id % 10) + 1))
-                .col("unit_price", DECIMAL_18_4, id -> BigDecimal.valueOf((id % 5000) * 100 + 50, 2)
-                        .setScale(4, RoundingMode.UNNECESSARY))
+                .col("order_id",   INT64,        id ->
+                        zipfLikePick(id, orderCount, ZIPF_ALPHA, FK_ORDER))
+                .col("product_id", INT64,        id ->
+                        zipfLikePick(id, productCount, ZIPF_ALPHA, FK_PRODUCT))
+                .col("qty",        INT32,        id -> intMod(id, N_QTY, 10) + 1)
+                .col("unit_price", DECIMAL_18_4, id ->
+                        BigDecimal.valueOf((id % 5000) * 100 + 50, 2)
+                                .setScale(4, RoundingMode.UNNECESSARY))
                 .partition(PartitionStyle.RANGE_INT, "order_id")
                 .build();
     }
@@ -106,54 +265,65 @@ public final class ShopScenarios {
     public static TableScenario payments(long n, long orderCount) {
         return Scenario.table("payments", n)
                 .col("id",       INT64,        id -> id)
-                .col("order_id", INT64,        id -> (id % orderCount) + 1)
-                .col("amount",   DECIMAL_18_4, id -> BigDecimal.valueOf(id * 11, 2)
-                        .setScale(4, RoundingMode.UNNECESSARY))
-                .col("method",   STRING,       id -> METHODS[(int) (id % 4)])
-                .col("paid_at",  DATETIME,     id -> BASE_DT.plusSeconds(id + 30))
+                .col("order_id", INT64,        id ->
+                        zipfLikePick(id, orderCount, ZIPF_ALPHA, FK_ORDER))
+                .col("amount",   DECIMAL_18_4, id ->
+                        BigDecimal.valueOf(id * 11, 2)
+                                .setScale(4, RoundingMode.UNNECESSARY))
+                .col("method",   STRING,       id ->
+                        weighted(id, METHODS, METHODS_W, CAT_METHOD))
+                .col("paid_at",  DATETIME,     id -> randomTime(id, T_PAID))
                 .partition(PartitionStyle.LIST_STRING, "method")
                 .build();
     }
 
-    public static TableScenario reviews(long n, long userCount) {
+    public static TableScenario reviews(long n, long userCount, long productCount) {
         return Scenario.table("reviews", n)
                 .col("id",          INT64,    id -> id)
-                .col("product_id",  INT64,    id -> (id % n) + 1)
-                .col("user_id",     INT64,    id -> (id % userCount) + 1)
-                .col("rating",      INT32,    id -> (int) (id % 5) + 1)
+                .col("product_id",  INT64,    id ->
+                        zipfLikePick(id, productCount, ZIPF_ALPHA, FK_PRODUCT))
+                .col("user_id",     INT64,    id ->
+                        zipfLikePick(id, userCount, ZIPF_ALPHA, FK_USER))
+                .col("rating",      INT32,    id -> intMod(id, N_RATING, 5) + 1)
                 .col("review_text", STRING,   id -> "Отзыв №" + id)
-                .col("reviewed_at", DATETIME, id -> BASE_DT.plusSeconds(id * 2))
+                .col("reviewed_at", DATETIME, id -> randomTime(id, T_REVIEWED))
+                .partition(PartitionStyle.RANGE_DATE, "reviewed_at")
                 .build();
     }
 
     public static TableScenario addresses(long n, long userCount) {
-        final String[] cities =
-                {"Москва", "Санкт-Петербург", "Казань", "Новосибирск", "Екатеринбург"};
         return Scenario.table("addresses", n)
                 .col("id",          INT64,  id -> id)
-                .col("user_id",     INT64,  id -> (id % userCount) + 1)
-                .col("city",        STRING, id -> cities[(int) (id % 5)])
-                .col("street",      STRING, id -> "ул. Тестовая, д. " + id)
-                .col("postal_code", STRING, id -> String.format("%06d", id % 200000))
-                .col("is_default",  BOOL,   id -> id % 3 == 0)
+                .col("user_id",     INT64,  id ->
+                        zipfLikePick(id, userCount, ZIPF_ALPHA, FK_USER))
+                .col("city",        STRING, id -> pickFromArray(id, CITIES, TXT_CITY))
+                .col("street",      STRING, ShopScenarios::makeStreet)
+                .col("postal_code", STRING, id ->
+                        String.format("%06d", intMod(id, N_POSTAL, 200000)))
+                .col("is_default",  BOOL,   id -> oneIn(id, B_DEFAULT, 3))
+                .partition(PartitionStyle.HASH_INT, "user_id")
                 .build();
     }
 
     public static TableScenario shipments(long n, long orderCount, long addressCount) {
         return Scenario.table("shipments", n)
-                .col("id",            INT64,           id -> id)
-                .col("order_id",      INT64,           id -> (id % orderCount) + 1)
-                .col("address_id",    INT64,           id -> (id % addressCount) + 1)
-                .col("shipped_at",    DATETIME,        id -> BASE_DT.plusSeconds(id + 60))
-                .col("tracking_code", STRING,          id -> id % 4 == 0 ? null : "TRK-" + id)
+                .col("id",            INT64,    id -> id)
+                .col("order_id",      INT64,    id ->
+                        zipfLikePick(id, orderCount, ZIPF_ALPHA, FK_ORDER))
+                .col("address_id",    INT64,    id ->
+                        zipfLikePick(id, addressCount, ZIPF_ALPHA, FK_ADDRESS))
+                .col("shipped_at",    DATETIME, id -> randomTime(id, T_SHIPPED))
+                .col("tracking_code", STRING,   id ->
+                        oneIn(id, G_TRACKING, 4) ? null : "TRK-" + id)
                 .partition(PartitionStyle.HASH_INT, "address_id")
                 .build();
     }
 
-    public static TableScenario productImages(long n) {
+    public static TableScenario productImages(long n, long productCount) {
         return Scenario.table("product_images", n)
                 .col("id",         INT64,  id -> id)
-                .col("product_id", INT64,  id -> (id % n) + 1)
+                .col("product_id", INT64,  id ->
+                        zipfLikePick(id, productCount, ZIPF_ALPHA, FK_PRODUCT))
                 .col("caption",    STRING, id -> "Image #" + id)
                 .blob("image_data", ShopScenarios::imageBytes)
                 .build();
@@ -181,28 +351,68 @@ public final class ShopScenarios {
     public static TableScenario auditLog(long n) {
         return Scenario.table("audit_log", n)
                 .col("id",          INT64,    id -> id)
-                .col("entity_type", STRING,   id -> ENTITY_TYPES[(int) (id % 5)])
-                .col("entity_id",   INT64,    id -> id * 3)
-                .col("action_type", STRING,   id -> EVENT_TYPES[(int) (id % 5)])
-                .col("ts",          DATETIME, id -> BASE_DT.plusSeconds(id))
+                .col("entity_type", STRING,   id ->
+                        weighted(id, ENTITY_TYPES, ENTITY_W, CAT_ENTITY))
+                .col("entity_id",   INT64,    id ->
+                        Math.floorMod(stableHash(id, FK_ORDER), Math.max(1L, n)) + 1)
+                .col("action_type", STRING,   id ->
+                        weighted(id, EVENT_TYPES, EVENT_W, CAT_EVENT))
+                .col("ts",          DATETIME, id -> randomTime(id, T_TS))
                 .partition(PartitionStyle.RANGE_DATE, "ts")
                 .build();
     }
 
     public static List<TableScenario> all(long n) {
+        long categoryCount = Math.max(10L, n / 1000L);
+        long userCount     = Math.max(1L, n / 2L);
+        long productCount  = Math.max(1L, n / 2L);
+        long addressCount  = Math.max(1L, n / 2L);
+        long reviewsCount  = Math.max(1L, n / 4L);
+        long orderCount    = n;
+        long inventoryN    = n;
+        long paymentsCount = 5L * n / 4L;
+        long shipmentsCnt  = n;
+        long orderItemsCnt = 11L * n / 4L;
+        long auditCount    = 11L * n / 4L;
+
         List<TableScenario> list = new ArrayList<>();
-        list.add(users(n));
-        list.add(categories(n));
-        list.add(products(n));
-        list.add(inventory(n));
-        list.add(orders(n, n));
-        list.add(orderItems(n, n));
-        list.add(payments(n, n));
-        list.add(reviews(n, n));
-        list.add(addresses(n, n));
-        list.add(shipments(n, n, n));
-        list.add(productImages(BLOB_ROW_COUNT));
-        list.add(auditLog(n));
+        list.add(users(userCount));
+        list.add(categories(categoryCount));
+        list.add(products(productCount, categoryCount));
+        list.add(inventory(inventoryN, productCount));
+        list.add(orders(orderCount, userCount));
+        list.add(orderItems(orderItemsCnt, orderCount, productCount));
+        list.add(payments(paymentsCount, orderCount));
+        list.add(reviews(reviewsCount, userCount, productCount));
+        list.add(addresses(addressCount, userCount));
+        list.add(shipments(shipmentsCnt, orderCount, addressCount));
+        list.add(productImages(BLOB_ROW_COUNT, productCount));
+        list.add(auditLog(auditCount));
         return list;
+    }
+
+    public static List<TableScenario> uniform(int tables, long rowsPerTable) {
+        List<TableScenario> list = new ArrayList<>(tables);
+        for (int i = 0; i < tables; i++) {
+            list.add(uniformTable("uniform_" + i, rowsPerTable));
+        }
+        return list;
+    }
+
+    private static TableScenario uniformTable(String name, long n) {
+        final long userCount = Math.max(1L, n / 2L);
+        return Scenario.table(name, n)
+                .col("id",        INT64,        id -> id)
+                .col("user_id",   INT64,        id ->
+                        zipfLikePick(id, userCount, ZIPF_ALPHA, FK_USER))
+                .col("total",     DECIMAL_18_4, id ->
+                        BigDecimal.valueOf(id * 13, 2)
+                                .setScale(4, RoundingMode.UNNECESSARY))
+                .col("currency",  STRING,       id ->
+                        weighted(id, CURRENCIES, CURRENCIES_W, CAT_CURRENCY))
+                .col("placed_at", DATETIME,     id -> randomTime(id, T_PLACED))
+                .col("status",    STRING,       id ->
+                        weighted(id, STATUSES, STATUSES_W, CAT_STATUS))
+                .build();
     }
 }

--- a/src/test/java/tech/ydb/importer/integration/verification/SourceDbProfile.java
+++ b/src/test/java/tech/ydb/importer/integration/verification/SourceDbProfile.java
@@ -11,12 +11,23 @@ import java.util.Set;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.integration.sources.clickhouse.ClickHouseLoader;
+import tech.ydb.importer.integration.sources.clickhouse.ClickHouseTestContainer;
+import tech.ydb.importer.integration.sources.db2.Db2Loader;
+import tech.ydb.importer.integration.sources.db2.Db2TestContainer;
+import tech.ydb.importer.integration.sources.greenplum.GreenplumTestContainer;
+import tech.ydb.importer.integration.sources.hana.HanaLoader;
+import tech.ydb.importer.integration.sources.hana.HanaTestContainer;
+import tech.ydb.importer.integration.sources.mariadb.MariaDbLoader;
+import tech.ydb.importer.integration.sources.mariadb.MariaDbTestContainer;
 import tech.ydb.importer.integration.sources.mysql.MySqlLoader;
 import tech.ydb.importer.integration.sources.mysql.MySqlTestContainer;
 import tech.ydb.importer.integration.sources.oracle.OracleLoader;
 import tech.ydb.importer.integration.sources.oracle.OracleTestContainer;
 import tech.ydb.importer.integration.sources.postgres.PostgresLoader;
 import tech.ydb.importer.integration.sources.postgres.PostgresTestContainer;
+import tech.ydb.importer.integration.sources.vertica.VerticaLoader;
+import tech.ydb.importer.integration.sources.vertica.VerticaTestContainer;
 import tech.ydb.importer.integration.verification.TableScenario.Feature;
 
 /** Source DB test profile with container, connection and dialect loader */
@@ -58,6 +69,22 @@ public final class SourceDbProfile {
         return name;
     }
 
+    public static SourceDbProfile clickhouse() {
+        return new SourceDbProfile("clickhouse",
+                ClickHouseTestContainer.create(),
+                SourceType.CLICKHOUSE, "default",
+                ClickHouseLoader.INSTANCE,
+                EnumSet.of(Feature.PARTITIONED));
+    }
+
+    public static SourceDbProfile mariadb(String dbName) {
+        return new SourceDbProfile("mariadb",
+                MariaDbTestContainer.create(dbName),
+                SourceType.MARIADB, dbName,
+                MariaDbLoader.INSTANCE,
+                EnumSet.of(Feature.BLOB, Feature.PARTITIONED));
+    }
+
     public static SourceDbProfile mysql(String dbName) {
         return new SourceDbProfile("mysql",
                 MySqlTestContainer.create(dbName),
@@ -74,6 +101,14 @@ public final class SourceDbProfile {
                 EnumSet.of(Feature.BLOB, Feature.PARTITIONED));
     }
 
+    public static SourceDbProfile greenplum() {
+        return new SourceDbProfile("greenplum",
+                new GreenplumTestContainer(),
+                SourceType.GREENPLUM, "public",
+                PostgresLoader.INSTANCE,
+                EnumSet.of(Feature.PARTITIONED));
+    }
+
     public static SourceDbProfile oracle() {
         return new SourceDbProfile("oracle",
                 OracleTestContainer.create(),
@@ -82,11 +117,41 @@ public final class SourceDbProfile {
                 EnumSet.of(Feature.BLOB, Feature.PARTITIONED));
     }
 
+    public static SourceDbProfile db2() {
+        return new SourceDbProfile("db2",
+                new Db2TestContainer(),
+                SourceType.DB2, Db2TestContainer.SCHEMA,
+                Db2Loader.INSTANCE,
+                EnumSet.of(Feature.BLOB, Feature.PARTITIONED));
+    }
+
+    public static SourceDbProfile vertica() {
+        return new SourceDbProfile("vertica",
+                new VerticaTestContainer(),
+                SourceType.VERTICA, "public",
+                VerticaLoader.INSTANCE,
+                EnumSet.of(Feature.BLOB, Feature.PARTITIONED));
+    }
+
+    public static SourceDbProfile hana() {
+        return new SourceDbProfile("hana",
+                new HanaTestContainer(),
+                SourceType.HANA, HanaTestContainer.SCHEMA,
+                HanaLoader.INSTANCE,
+                EnumSet.of(Feature.BLOB, Feature.PARTITIONED));
+    }
+
     public static List<SourceDbProfile> all(String defaultDbName) {
         List<SourceDbProfile> list = new ArrayList<>();
-        list.add(postgres(defaultDbName));
+        list.add(clickhouse());
+        list.add(mariadb(defaultDbName));
         list.add(mysql(defaultDbName));
+        list.add(postgres(defaultDbName));
+        list.add(greenplum());
         list.add(oracle());
+        list.add(db2());
+        list.add(vertica());
+        list.add(hana());
         return list;
     }
 }


### PR DESCRIPTION
## Новые источники

Добавлена поддержка пяти СУБД:

* ClickHouse
* MariaDB (включая ColumnStore)
* Vertica
* SAP HANA
* Greenplum

Для каждого источника написан свой `*TableLister` (листинг схем, таблиц и ключей под диалект):

* `GreenplumTableLister` наследует `PostgresTableLister`,
* `MariaDbTableLister` наследует `MySqlTableLister`,
* `VerticaTableLister`, `HanaTableLister` — отдельные листеры поверх `AnyTableLister`.

ClickHouse дополнительно: пропускает системные БД и таблицы-`View`, на время чтения останавливает фоновые слияния (`SYSTEM STOP/START MERGES` через `beforeTableRead`/`afterTableRead`), читает CLOB как строку (драйвер не поддерживает `getCharacterStream`).

### Улучшена поддержка DB2

Для DB2 добавлен выделенный `DB2TableLister`. Метаданные берутся прямыми запросами к системному каталогу DB2 (`SYSCAT.*`), таблица читается параллельно по партициям.

## Тесты

Для каждого нового источника добавлены интеграционные тесты на Testcontainers: свой `TestContainer`, `DialectLoader` (DDL и INSERT под диалект) для `ShopScenarios`.

## CI

Добавлен Actions workflow: checkstyle, юнит-тесты, проверка совместимости (PostgreSQL на JDK 8/11/17/21/25) и интеграционные тесты по каждой СУБД на JDK 8.

## Таймзоны

Раньше timestamp без таймзоны читались в зоне JVM, а в YDB записывались в UTC. Если зона JVM была не UTC+0, значения сдвигались на её смещение и данные искажались. Теперь чтение тоже идёт в UTC, и сдвига нет.
