### PR TITLE
Bug fixes

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -207,6 +207,9 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
              Применяется к партиционированным таблицам без колонок BLOB и CLOB.
          -->
         <retry-count>10</retry-count>
+        <!-- Размер выборки JDBC при чтении источника (по умолчанию 10000). У ClickHouse
+             нет курсора JDBC, поэтому для него этот параметр задаёт число строк в чанке чтения партиции. -->
+        <fetch-size>10000</fetch-size>
     </source>
     <!-- Параметры подключения к БД-получателю. -->
     <target type="ydb">

--- a/README-ru.md
+++ b/README-ru.md
@@ -293,8 +293,8 @@ ALTER DATABASE dbname SET lo_compat_privileges TO on;
                     задан, иначе числу партиций источника, если они есть.
              N    - целое >= 2, разбить диапазон первой колонки ключа на N равных
                     интервалов (по ydb-partition-from/to, иначе MIN/MAX источника).
-             none - не задавать, YDB управляет партициями сам.
-             По умолчанию none. Можно переопределить в <table-ref>. -->
+             ydb-managed - YDB управляет партициями сам.
+             По умолчанию ydb-managed. Можно переопределить в <table-ref>. -->
         <ydb-partition-count>auto</ydb-partition-count>
     </table-options>
     <!-- Фильтр для отбора копируемых таблиц с источника -->

--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ Below is the definition of the configuration file structure:
                     otherwise the number of source partitions if any (see section 5).
              N    - integer >= 2, split the first key column range into N equal
                     intervals (from ydb-partition-from/to, otherwise source MIN/MAX).
-             none - do not set it, YDB manages partitions on its own.
-             Default is none. Can be overridden in <table-ref>. -->
+             ydb-managed - YDB manages partitions on its own.
+             Default is ydb-managed. Can be overridden in <table-ref>. -->
         <ydb-partition-count>auto</ydb-partition-count>
     </table-options>
     <!-- Table map filters the source tables and defines the conversion modes for them. -->

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ Below is the definition of the configuration file structure:
              Applies to partitioned tables without BLOB or CLOB columns.
          -->
         <retry-count>10</retry-count>
+        <!-- JDBC fetch size for source reads (default 10000). For ClickHouse
+             (no JDBC cursor) it sets the rows per partition read chunk instead. -->
+        <fetch-size>10000</fetch-size>
     </source>
     <!-- Target YDB database connection parameters. -->
     <target type="ydb">

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Below is the definition of the configuration file structure:
              INT saves date as 32-bit integer YYYYMMDD for dates,
                  and as a 64-bit milliseconds since epoch for timestamps.
              STR saves dates as character strings (Utf8) in format "YYYY-MM-DD",
-                 and in "YYYY-MM-DD hh:mm:ss.xxx" for timestamps.
+                 and in "YYYY-MM-DDTHH:MM:SS[.SSSSSSSSS]Z" for timestamps.
          -->
         <conv-date>DATE_NEW</conv-date>
         <conv-timestamp>DATE_NEW</conv-timestamp>

--- a/src/main/java/tech/ydb/importer/YdbImporter.java
+++ b/src/main/java/tech/ydb/importer/YdbImporter.java
@@ -305,15 +305,19 @@ public class YdbImporter {
                     LOG.info("No valid tables to be loaded, nothing to do.");
                     return;
                 }
-                int successCount = 0;
                 for (Future<Boolean> rf : results) {
-                    if (rf.get() != null && rf.get()) {
-                        ++successCount;
-                    }
+                    rf.get();
                 }
 
                 writerPool.shutdownAndWait();
-                LOG.info("Table data load completed {} of {} tasks.", successCount, results.size());
+                int failed = 0;
+                for (TableDecision td : tables) {
+                    if (td.isFailure()) {
+                        ++failed;
+                    }
+                }
+                LOG.info("Table data load completed {} of {} tables.",
+                        tables.size() - failed, tables.size());
             } finally {
                 writerPool.close();
             }

--- a/src/main/java/tech/ydb/importer/YdbImporter.java
+++ b/src/main/java/tech/ydb/importer/YdbImporter.java
@@ -381,9 +381,11 @@ public class YdbImporter {
     }
 
     public static String getVersion() {
-        try {
-            Properties prop = new Properties();
-            InputStream in = YdbImporter.class.getResourceAsStream("/importer_version.properties");
+        final Properties prop = new Properties();
+        try (InputStream in = YdbImporter.class.getResourceAsStream("/importer_version.properties")) {
+            if (in == null) {
+                return "unknown";
+            }
             prop.load(in);
             return prop.getProperty("version");
         } catch (IOException ex) {

--- a/src/main/java/tech/ydb/importer/config/TableOptions.java
+++ b/src/main/java/tech/ydb/importer/config/TableOptions.java
@@ -210,8 +210,8 @@ public class TableOptions extends JdomHelper {
          */
         DATE,
         /**
-         * Date or time as string, using formats "YYYY-MM-DD",
-         * "YYYY-MM-DDTHH:MM:SSZ" and "YYYY-MM-DDTHH:MM:SS.SSSZ".
+         * Date or time as string, using formats "YYYY-MM-DD" and
+         * "YYYY-MM-DDTHH:MM:SS[.SSSSSSSSS]Z".
          */
         STR,
         /**

--- a/src/main/java/tech/ydb/importer/config/TableRef.java
+++ b/src/main/java/tech/ydb/importer/config/TableRef.java
@@ -102,7 +102,7 @@ public class TableRef extends JdomHelper implements TableIdentity {
         if (text == null || "auto".equalsIgnoreCase(text.trim())) {
             return AUTO;
         }
-        if (allowNone && "none".equalsIgnoreCase(text.trim())) {
+        if (allowNone && "ydb-managed".equalsIgnoreCase(text.trim())) {
             return NONE;
         }
         int n;
@@ -112,7 +112,7 @@ public class TableRef extends JdomHelper implements TableIdentity {
             throw raiseIllegal(c, name, text);
         }
         if (n < 2) {
-            String allowed = allowNone ? "'auto', 'none' or an integer >= 2"
+            String allowed = allowNone ? "'auto', 'ydb-managed' or an integer >= 2"
                     : "'auto' or an integer >= 2";
             throw raise(c, name + " must be " + allowed);
         }

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -222,6 +222,7 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
                     ci.setSqlPrecision(rsmd.getPrecision(i));
                     ci.setSqlScale(rsmd.getScale(i));
                     ci.setNullable(rsmd.isNullable(i) != 0);
+                    ci.setUnsigned(!rsmd.isSigned(i));
                 }
             }
         } catch (Exception ex) {

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -61,6 +61,10 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
         return false;
     }
 
+    public boolean defaultAutoCommit() {
+        return false;
+    }
+
     // Safely quote the identifier
     protected abstract String safeId(String id);
 

--- a/src/main/java/tech/ydb/importer/source/AnyTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/AnyTableLister.java
@@ -341,13 +341,21 @@ public abstract class AnyTableLister extends tech.ydb.importer.config.JdomHelper
             case CLICKHOUSE:
                 return new ClickHouseTableLister(tableMaps);
             case DB2:
-                return new DB2TableLister(tableMaps);
+                if (isDb2Luw(con)) {
+                    return new DB2TableLister(tableMaps);
+                }
+                return new GenericJdbcTableLister(tableMaps, con);
             case INFORMIX:
             case MSSQL:
                 return new GenericJdbcTableLister(tableMaps, con);
             default:
                 throw new RuntimeException("Unsupported source type: " + st);
         }
+    }
+
+    private static boolean isDb2Luw(Connection con) throws SQLException {
+        String version = con.getMetaData().getDatabaseProductVersion();
+        return version != null && version.startsWith("SQL");
     }
 
 }

--- a/src/main/java/tech/ydb/importer/source/AutoBoundsResolver.java
+++ b/src/main/java/tech/ydb/importer/source/AutoBoundsResolver.java
@@ -151,7 +151,7 @@ final class AutoBoundsResolver {
                 upper = r.upper;
                 strategy = "by source key range";
             }
-            applyEqualSplit(td, tm, type, lower, upper, requestedN, strategy);
+            applyEqualSplit(td, tm, type, new Range(lower, upper), requestedN, strategy, false);
             return;
         }
 
@@ -167,8 +167,10 @@ final class AutoBoundsResolver {
             if (r == null) {
                 return;
             }
-            applyEqualSplit(td, tm, type, r.lower, r.upper, ref.getSplitCount(),
-                    "by source key range");
+            boolean onePartitionPerTask = leading.getName().equals(ref.getSplitBy())
+                    && ref.getSplitFrom() == null && ref.getSplitTo() == null;
+            applyEqualSplit(td, tm, type, r, ref.getSplitCount(),
+                    "by source key range", onePartitionPerTask);
             return;
         }
         // mirror source partitions with disjoint key ranges.
@@ -217,7 +219,7 @@ final class AutoBoundsResolver {
         if (cuts == null) {
             return false;
         }
-        applyCuts(td, tm, cuts, ranges.size(), "by source partitions");
+        applyCuts(td, tm, cuts, ranges.size(), "by source partitions", true);
         return true;
     }
 
@@ -248,8 +250,8 @@ final class AutoBoundsResolver {
     }
 
     private void applyCuts(TableDecision td, TableMetadata tm,
-            List<String> cuts, int n, String strategy) {
-        tm.setYdbPartitioning(YdbPartitioning.keyRange(cuts, strategy));
+            List<String> cuts, int n, String strategy, boolean onePartitionPerTask) {
+        tm.setYdbPartitioning(YdbPartitioning.keyRange(cuts, strategy, onePartitionPerTask));
         TableRef ref = td.getTableRef();
         if (ref != null) {
             ref.setYdbPartitionCount(n);
@@ -257,10 +259,10 @@ final class AutoBoundsResolver {
     }
 
     private void applyEqualSplit(TableDecision td, TableMetadata tm,
-            SplitColumnType type, String from, String to, int n, String strategy) {
+            SplitColumnType type, Range range, int n, String strategy, boolean onePartitionPerTask) {
         try {
-            List<String> cuts = RangeSplitter.computeCuts(from, to, n, type);
-            applyCuts(td, tm, cuts, n, strategy);
+            List<String> cuts = RangeSplitter.computeCuts(range.lower, range.upper, n, type);
+            applyCuts(td, tm, cuts, n, strategy, onePartitionPerTask);
         } catch (IllegalArgumentException ex) {
             LOG.warn("Cannot compute YDB partitioning cuts for {}.{}: {}",
                     td.getSchema(), td.getTable(), ex.getMessage());

--- a/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
@@ -127,8 +127,9 @@ public class ClickHouseTableLister extends AnyTableLister {
     }
 
     /*
-     * ClickHouse reports UInt64 as OTHER. Read the column type from the catalog and
-     * remap a plain UInt64 to NUMERIC(20,0).
+     * ClickHouse JDBC reports UInt8/16/32 as larger signed types and UInt64 as OTHER.
+     * Read the type from system.columns and set those columns unsigned, so the mapper
+     * picks Uint8/Uint16/Uint32/Uint64.
      */
     @Override
     protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
@@ -142,28 +143,47 @@ public class ClickHouseTableLister extends AnyTableLister {
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     ColumnInfo ci = tm.findColumn(rs.getString(1));
-                    if (ci == null || ci.getSqlType() != java.sql.Types.OTHER) {
+                    if (ci == null) {
                         continue;
                     }
-                    if (isUInt64Type(rs.getString(2))) {
-                        ci.setSqlType(java.sql.Types.NUMERIC);
-                        ci.setSqlPrecision(20);
-                        ci.setSqlScale(0);
-                    }
+                    markUnsignedInteger(ci, unwrap(rs.getString(2)));
                 }
             }
         }
     }
 
-    private static boolean isUInt64Type(String type) {
+    private static void markUnsignedInteger(ColumnInfo ci, String inner) {
+        switch (inner) {
+            case "UInt8":
+                ci.setSqlType(java.sql.Types.TINYINT);
+                ci.setUnsigned(true);
+                break;
+            case "UInt16":
+                ci.setSqlType(java.sql.Types.SMALLINT);
+                ci.setUnsigned(true);
+                break;
+            case "UInt32":
+                ci.setSqlType(java.sql.Types.INTEGER);
+                ci.setUnsigned(true);
+                break;
+            case "UInt64":
+                ci.setSqlType(java.sql.Types.BIGINT);
+                ci.setUnsigned(true);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static String unwrap(String type) {
         if (type == null) {
-            return false;
+            return "";
         }
         String inner = type.trim();
         while (inner.startsWith("LowCardinality(") || inner.startsWith("Nullable(")) {
             inner = inner.substring(inner.indexOf('(') + 1, inner.length() - 1).trim();
         }
-        return inner.equals("UInt64");
+        return inner;
     }
 
     @Override

--- a/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/ClickHouseTableLister.java
@@ -253,6 +253,11 @@ public class ClickHouseTableLister extends AnyTableLister {
     }
 
     @Override
+    public boolean defaultAutoCommit() {
+        return true;
+    }
+
+    @Override
     protected String safeId(String id) {
         if (id.contains("`")) {
             throw new IllegalArgumentException("Backtick within the identifier: " + id);

--- a/src/main/java/tech/ydb/importer/source/ColumnInfo.java
+++ b/src/main/java/tech/ydb/importer/source/ColumnInfo.java
@@ -15,6 +15,7 @@ public class ColumnInfo {
     private int sqlScale;
     private boolean nullable;
     private boolean blobAsObject;
+    private boolean unsigned;
 
     public ColumnInfo(String name) {
         this.name = (name == null) ? "" : name;
@@ -25,6 +26,7 @@ public class ColumnInfo {
         this.sqlScale = 0;
         this.nullable = true;
         this.blobAsObject = false;
+        this.unsigned = false;
     }
 
     public String getName() {
@@ -81,6 +83,14 @@ public class ColumnInfo {
 
     public void setBlobAsObject(boolean blobAsObject) {
         this.blobAsObject = blobAsObject;
+    }
+
+    public boolean isUnsigned() {
+        return unsigned;
+    }
+
+    public void setUnsigned(boolean unsigned) {
+        this.unsigned = unsigned;
     }
 
     public static boolean isBlob(int sqlType) {

--- a/src/main/java/tech/ydb/importer/source/DB2TableLister.java
+++ b/src/main/java/tech/ydb/importer/source/DB2TableLister.java
@@ -48,7 +48,6 @@ public class DB2TableLister extends AnyTableLister {
                     if (value == null) {
                         continue;
                     }
-                    value = value.trim();
                     if (value.startsWith("SYS") || value.startsWith("IBM")) {
                         continue;
                     }
@@ -72,7 +71,7 @@ public class DB2TableLister extends AnyTableLister {
             try (ResultSet rs = ps.executeQuery()) {
                 final List<String> retval = new ArrayList<>();
                 while (rs.next()) {
-                    retval.add(rs.getString(1).trim());
+                    retval.add(rs.getString(1));
                 }
                 return retval;
             }
@@ -109,7 +108,7 @@ public class DB2TableLister extends AnyTableLister {
             ps.setString(2, ti.getTable());
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    cols.add(new ColumnInfo(rs.getString(1).trim()));
+                    cols.add(new ColumnInfo(rs.getString(1)));
                 }
             }
         }
@@ -143,7 +142,7 @@ public class DB2TableLister extends AnyTableLister {
             ps.setString(2, ti.getTable());
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    tm.addKey(rs.getString(1).trim());
+                    tm.addKey(rs.getString(1));
                 }
             }
         }
@@ -179,8 +178,8 @@ public class DB2TableLister extends AnyTableLister {
             ps.setString(2, ti.getTable());
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    bestIndSchema = rs.getString(1).trim();
-                    bestIndName = rs.getString(2).trim();
+                    bestIndSchema = rs.getString(1);
+                    bestIndName = rs.getString(2);
                 }
             }
         }
@@ -196,7 +195,7 @@ public class DB2TableLister extends AnyTableLister {
             ps.setString(2, bestIndName);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    tm.addKey(rs.getString(1).trim());
+                    tm.addKey(rs.getString(1));
                 }
             }
         }

--- a/src/main/java/tech/ydb/importer/source/HanaTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/HanaTableLister.java
@@ -116,6 +116,8 @@ public class HanaTableLister extends AnyTableLister {
     /**
      * HANA JDBC reports TIMESTAMP with scale=0, which maps to Datetime64
      * and loses fractional seconds. Tag scale=7 so the mapper picks Timestamp64.
+     * SMALLDECIMAL is reported as DECIMAL scale=0, which maps to Int64 and loses
+     * the fraction. Tag scale=-1 so the mapper picks Double.
      */
     @Override
     protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
@@ -128,12 +130,18 @@ public class HanaTableLister extends AnyTableLister {
             ps.setString(2, td.getTable());
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    if (!"TIMESTAMP".equals(rs.getString(2))) {
+                    String dataType = rs.getString(2);
+                    ColumnInfo ci = tm.findColumn(rs.getString(1));
+                    if (ci == null) {
                         continue;
                     }
-                    ColumnInfo ci = tm.findColumn(rs.getString(1));
-                    if (ci != null && ci.getSqlType() == java.sql.Types.TIMESTAMP) {
+                    if ("TIMESTAMP".equals(dataType)
+                            && ci.getSqlType() == java.sql.Types.TIMESTAMP) {
                         ci.setSqlScale(7);
+                    } else if ("SMALLDECIMAL".equals(dataType)
+                            && (ci.getSqlType() == java.sql.Types.DECIMAL
+                                || ci.getSqlType() == java.sql.Types.NUMERIC)) {
+                        ci.setSqlScale(-1);
                     }
                 }
             }

--- a/src/main/java/tech/ydb/importer/source/MySqlTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/MySqlTableLister.java
@@ -105,6 +105,35 @@ public class MySqlTableLister extends AnyTableLister {
         return cols;
     }
 
+    /**
+     * MySQL JDBC reports DATETIME(N)/TIMESTAMP(N) with scale=0, which maps to Datetime64
+     * and loses fractional seconds. Read the scale from the catalog so the mapper
+     * picks Timestamp64.
+     */
+    @Override
+    protected void grabColumnTypes(Connection con, TableDecision td, TableMetadata tm)
+            throws SQLException {
+        super.grabColumnTypes(con, td, tm);
+        try (PreparedStatement ps = con.prepareStatement(
+                "SELECT column_name, datetime_precision FROM information_schema.columns "
+                + "WHERE table_schema=? AND table_name=?")) {
+            ps.setString(1, td.getSchema());
+            ps.setString(2, td.getTable());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int frac = rs.getInt(2);
+                    if (rs.wasNull() || frac <= 0) {
+                        continue;
+                    }
+                    ColumnInfo ci = tm.findColumn(rs.getString(1));
+                    if (ci != null && ci.getSqlType() == java.sql.Types.TIMESTAMP) {
+                        ci.setSqlScale(frac);
+                    }
+                }
+            }
+        }
+    }
+
     @Override
     protected void grabPrimaryKey(Connection con, TableIdentity ti, TableMetadata tm)
             throws SQLException {

--- a/src/main/java/tech/ydb/importer/source/SourceCP.java
+++ b/src/main/java/tech/ydb/importer/source/SourceCP.java
@@ -7,7 +7,6 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import tech.ydb.importer.config.SourceConfig;
-import tech.ydb.importer.config.SourceType;
 
 /**
  * Connection pool wrapper object
@@ -20,9 +19,6 @@ public class SourceCP implements AutoCloseable {
 
     public SourceCP(SourceConfig sc, int poolSize) throws SQLException {
         HikariConfig hc = new HikariConfig();
-        if (SourceType.CLICKHOUSE != sc.getType()) {
-            hc.setAutoCommit(false);
-        }
         hc.setJdbcUrl(sc.getJdbcUrl());
         hc.setUsername(sc.getUserName());
         hc.setPassword(sc.getPassword());

--- a/src/main/java/tech/ydb/importer/source/VerticaTableLister.java
+++ b/src/main/java/tech/ydb/importer/source/VerticaTableLister.java
@@ -206,7 +206,8 @@ public class VerticaTableLister extends AnyTableLister {
                 while (rs.next()) {
                     String partKey = rs.getString(1);
                     if (partKey == null) {
-                        continue;
+                        throw new IllegalStateException("Unexpected NULL partition_key for "
+                                + td.getSchema() + "." + td.getTable());
                     }
                     String escapedKey = partKey.replace("'", "''");
                     String whereSql = baseSql + " WHERE " + partitionExpr + " = '" + escapedKey + "'";

--- a/src/main/java/tech/ydb/importer/source/YdbPartitioning.java
+++ b/src/main/java/tech/ydb/importer/source/YdbPartitioning.java
@@ -12,21 +12,23 @@ public final class YdbPartitioning {
     public enum Mode { DEFAULT, KEY_RANGE, HASH }
 
     private static final YdbPartitioning DEFAULT =
-            new YdbPartitioning(Mode.DEFAULT, Collections.emptyList(), 0, null, null);
+            new YdbPartitioning(Mode.DEFAULT, Collections.emptyList(), 0, null, null, false);
 
     private final Mode mode;
     private final List<String> cuts;
     private final int hashPartitions;
     private final String hashColumn;
     private final String strategy;
+    private final boolean onePartitionPerTask;
 
     private YdbPartitioning(Mode mode, List<String> cuts, int hashPartitions,
-            String hashColumn, String strategy) {
+            String hashColumn, String strategy, boolean onePartitionPerTask) {
         this.mode = mode;
         this.cuts = cuts;
         this.hashPartitions = hashPartitions;
         this.hashColumn = hashColumn;
         this.strategy = strategy;
+        this.onePartitionPerTask = onePartitionPerTask;
     }
 
     /** Automatic YDB partitioning. */
@@ -35,15 +37,17 @@ public final class YdbPartitioning {
     }
 
     /** Row table split by key boundaries. */
-    public static YdbPartitioning keyRange(List<String> cuts, String strategy) {
+    public static YdbPartitioning keyRange(List<String> cuts, String strategy,
+            boolean onePartitionPerTask) {
         return new YdbPartitioning(Mode.KEY_RANGE,
-                Collections.unmodifiableList(new ArrayList<>(cuts)), 0, null, strategy);
+                Collections.unmodifiableList(new ArrayList<>(cuts)), 0, null, strategy,
+                onePartitionPerTask);
     }
 
     /** Column table split by key hash. */
     public static YdbPartitioning hash(int partitions, String hashColumn) {
         return new YdbPartitioning(Mode.HASH, Collections.emptyList(),
-                partitions, hashColumn, "by key hash");
+                partitions, hashColumn, "by key hash", false);
     }
 
     public boolean isKeyRange() {
@@ -71,5 +75,10 @@ public final class YdbPartitioning {
 
     public String getStrategy() {
         return strategy;
+    }
+
+    /** Read slices and YDB partitions have the same key boundaries. */
+    public boolean isOnePartitionPerTask() {
+        return onePartitionPerTask;
     }
 }

--- a/src/main/java/tech/ydb/importer/target/ArrowValueWriter.java
+++ b/src/main/java/tech/ydb/importer/target/ArrowValueWriter.java
@@ -59,6 +59,16 @@ public class ArrowValueWriter implements ValueWriter {
     }
 
     @Override
+    public void writeUint8(int idx, int v) {
+        row.writeUint8(columnNames[idx], v);
+    }
+
+    @Override
+    public void writeUint16(int idx, int v) {
+        row.writeUint16(columnNames[idx], v);
+    }
+
+    @Override
     public void writeInt32(int idx, int v) {
         row.writeInt32(columnNames[idx], v);
     }

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -151,7 +151,7 @@ public class LoadDataTask implements Callable<Boolean> {
                     savedRowIndex = rowIndex;
                     TaskQuery query = queries.get(nextQuery);
                     if (queries.size() > 1) {
-                        LOG.info("Reading range {}", query.getName());
+                        LOG.debug("Reading range {}", query.getName());
                     }
                     copied += executeQuery(con, query.getSql());
                     nextQuery++;

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -21,6 +21,7 @@ import tech.ydb.importer.source.ColumnInfo;
 import tech.ydb.importer.source.SourceCP;
 import tech.ydb.importer.source.TaskInfo;
 import tech.ydb.importer.source.TaskQuery;
+import tech.ydb.importer.source.YdbPartitioning;
 import tech.ydb.table.query.BulkUpsertData;
 import tech.ydb.table.query.arrow.ApacheArrowData;
 import tech.ydb.table.query.arrow.ApacheArrowWriter;
@@ -200,8 +201,9 @@ public class LoadDataTask implements Callable<Boolean> {
         final List<ClobReader> clobReaders = collectClobReaders(columns);
         final SynthKey synthKey = tab.getTarget().hasSynthKey() ? new SynthKey() : null;
 
-        PartitionBounds pb = partitionBuffers ? resolvePartitionBounds(rsmd) : null;
-        if (partitionBuffers && pb == null) {
+        boolean needsBuffering = needsPartitionBuffering();
+        PartitionBounds pb = (partitionBuffers && needsBuffering) ? resolvePartitionBounds(rsmd) : null;
+        if (partitionBuffers && needsBuffering && pb == null) {
             LOG.debug("partition-buffers requested for {}.{} but no integer partition cuts, "
                     + "plain batching", tab.getSchema(), tab.getTable());
         }
@@ -353,6 +355,12 @@ public class LoadDataTask implements Callable<Boolean> {
         final ApacheArrowData data = arrowBatch.buildBatch();
         writerPool.submit(new UploadBatch(ydbOp, data, rowCount,
                 () -> ArrowValueWriter.logValues(data), tab));
+    }
+
+    private boolean needsPartitionBuffering() {
+        final YdbPartitioning part = tab.getMetadata().getYdbPartitioning();
+        return !(part.isKeyRange() && part.isOnePartitionPerTask()
+                && tab.getMetadata().getTasks().size() == part.getCuts().size() + 1);
     }
 
     /** Which YDB partition a key falls into, by binary search over the cuts. */

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -56,6 +56,7 @@ public class LoadDataTask implements Callable<Boolean> {
     private final boolean partitionBuffers;
     private final boolean useArrow;
     private final boolean useStringForClob;
+    private final boolean defaultAutoCommit;
     private final WriterPool writerPool;
     private long rowIndex;
 
@@ -89,6 +90,7 @@ public class LoadDataTask implements Callable<Boolean> {
         this.partitionBuffers = tab.partitionBuffers();
         this.useArrow = owner.getConfig().getWorkers().isUseArrow();
         this.useStringForClob = owner.getTableLister().useStringForClobRead();
+        this.defaultAutoCommit = owner.getTableLister().defaultAutoCommit();
         this.writerPool = writerPool;
         this.rowIndex = 0;
     }
@@ -143,6 +145,7 @@ public class LoadDataTask implements Callable<Boolean> {
 
         while (nextQuery < queries.size()) {
             try (Connection con = source.getConnection()) {
+                con.setAutoCommit(defaultAutoCommit);
                 while (nextQuery < queries.size()) {
                     checkCancelled();
                     savedRowIndex = rowIndex;

--- a/src/main/java/tech/ydb/importer/target/LoadDataTask.java
+++ b/src/main/java/tech/ydb/importer/target/LoadDataTask.java
@@ -346,13 +346,13 @@ public class LoadDataTask implements Callable<Boolean> {
     private void submitRowBatch(ListType paramListType, List<Value<?>> batch) throws Exception {
         final ListValue lv = paramListType.newValue(batch);
         writerPool.submit(new UploadBatch(ydbOp, new BulkUpsertData(lv), batch.size(),
-                () -> RowValueWriter.logValues(lv)));
+                () -> RowValueWriter.logValues(lv), tab));
     }
 
     private void submitArrowBatch(ApacheArrowWriter.Batch arrowBatch, int rowCount) throws Exception {
         final ApacheArrowData data = arrowBatch.buildBatch();
         writerPool.submit(new UploadBatch(ydbOp, data, rowCount,
-                () -> ArrowValueWriter.logValues(data)));
+                () -> ArrowValueWriter.logValues(data), tab));
     }
 
     /** Which YDB partition a key falls into, by binary search over the cuts. */

--- a/src/main/java/tech/ydb/importer/target/ProgressCounter.java
+++ b/src/main/java/tech/ydb/importer/target/ProgressCounter.java
@@ -167,8 +167,8 @@ public class ProgressCounter implements AutoCloseable {
 
             long readed = numRowsRRead.get();
             long writed = numRowsWritten.get();
-            double readedRate = 1000d * (readed - lastRead) / diff;
-            double writedRate = 1000d * (writed - lastWritten) / diff;
+            double readedRate = 1000d * readed / diff;
+            double writedRate = 1000d * writed / diff;
             String avgRead = avgMs(numReadNanos.get(), numReadBatches.get());
             String avgUpload = avgMs(numUploadNanos.get(), numUploadBatches.get());
 

--- a/src/main/java/tech/ydb/importer/target/RowValueWriter.java
+++ b/src/main/java/tech/ydb/importer/target/RowValueWriter.java
@@ -41,6 +41,16 @@ public class RowValueWriter implements ValueWriter {
     }
 
     @Override
+    public void writeUint8(int idx, int v) {
+        values[idx] = PrimitiveValue.newUint8(v);
+    }
+
+    @Override
+    public void writeUint16(int idx, int v) {
+        values[idx] = PrimitiveValue.newUint16(v);
+    }
+
+    @Override
     public void writeInt32(int idx, int v) {
         values[idx] = PrimitiveValue.newInt32(v);
     }

--- a/src/main/java/tech/ydb/importer/target/UploadBatch.java
+++ b/src/main/java/tech/ydb/importer/target/UploadBatch.java
@@ -1,5 +1,6 @@
 package tech.ydb.importer.target;
 
+import tech.ydb.importer.TableDecision;
 import tech.ydb.table.query.BulkUpsertData;
 
 /**
@@ -7,18 +8,31 @@ import tech.ydb.table.query.BulkUpsertData;
  */
 public class UploadBatch {
 
-    static final UploadBatch SHUTDOWN_SIGNAL = new UploadBatch(null, null, 0, null);
+    static final UploadBatch SHUTDOWN_SIGNAL = new UploadBatch(null, null, 0, null, null);
 
     private final YdbUpsertOp op;
     private final BulkUpsertData data;
     private final int rowCount;
     private final Runnable onFailure;
+    private final TableDecision tab;
 
-    public UploadBatch(YdbUpsertOp op, BulkUpsertData data, int rowCount, Runnable onFailure) {
+    public UploadBatch(YdbUpsertOp op, BulkUpsertData data, int rowCount, Runnable onFailure,
+            TableDecision tab) {
         this.op = op;
         this.data = data;
         this.rowCount = rowCount;
         this.onFailure = onFailure;
+        this.tab = tab;
+    }
+
+    public void markFailed() {
+        if (tab != null) {
+            tab.setFailure(true);
+        }
+    }
+
+    public String label() {
+        return tab == null ? "?" : tab.getSchema() + "." + tab.getTable();
     }
 
     public YdbUpsertOp getOp() {

--- a/src/main/java/tech/ydb/importer/target/ValueReader.java
+++ b/src/main/java/tech/ydb/importer/target/ValueReader.java
@@ -39,10 +39,14 @@ public abstract class ValueReader {
     private static final ValueReader FLOAT = new FloatReader(ValueWriter::writeFloat);
     private static final ValueReader DOUBLE = new DoubleReader(ValueWriter::writeDouble);
 
+    private static final ValueReader UINT8 = new IntReader(ValueWriter::writeUint8);
+    private static final ValueReader UINT16 = new IntReader(ValueWriter::writeUint16);
     private static final ValueReader INT32 = new IntReader(ValueWriter::writeInt32);
     private static final ValueReader UINT32 = new LongReader(ValueWriter::writeUint32);
     private static final ValueReader INT64 = new LongReader(ValueWriter::writeInt64);
     private static final ValueReader UINT64 = new LongReader(ValueWriter::writeUint64);
+    private static final ValueReader UINT64_BIG =
+            new BigDecimalReader((w, i, v) -> w.writeUint64(i, v.toBigInteger().longValue()));
 
     private static final ValueReader DATE = new DateReader((w, i, v) -> w.writeDate(i, v.toLocalDate()));
     private static final ValueReader DATE32 = new DateReader((w, i, v) -> w.writeDate32(i, v.toLocalDate()));
@@ -148,6 +152,10 @@ public abstract class ValueReader {
                     return FLOAT;
                 case Double:
                     return DOUBLE;
+                case Uint8:
+                    return UINT8;
+                case Uint16:
+                    return UINT16;
                 case Int32:
                     switch (sqlType) {
                         case java.sql.Types.TIME:
@@ -179,6 +187,8 @@ public abstract class ValueReader {
                             return DATE_UINT64;
                         case java.sql.Types.TIMESTAMP:
                             return TS_UINT64;
+                        case java.sql.Types.BIGINT:
+                            return UINT64_BIG;
                         default:
                             return UINT64;
                     }

--- a/src/main/java/tech/ydb/importer/target/ValueReader.java
+++ b/src/main/java/tech/ydb/importer/target/ValueReader.java
@@ -29,9 +29,6 @@ public abstract class ValueReader {
     private static final ThreadLocal<Calendar> UTC_CALENDAR =
             ThreadLocal.withInitial(() -> Calendar.getInstance(TimeZone.getTimeZone("UTC")));
 
-    private static final DateTimeFormatter UTC_TIMESTAMP_FORMAT =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
-
     private static final ValueReader BOOL = new BoolReader(ValueWriter::writeBool);
     private static final ValueReader INT_BOOL = new IntReader((w, i, v) -> w.writeBool(i, v != 0));
     private static final ValueReader STR_BOOL = new StringReader((w, i, v) -> w.writeBool(i, str2bool(v)));
@@ -71,7 +68,7 @@ public abstract class ValueReader {
     private static final ValueReader TS_INT64 = new TimestampReader((w, i, v) -> w.writeInt64(i, v.getTime()));
     private static final ValueReader TS_UINT64 = new TimestampReader((w, i, v) -> w.writeUint64(i, v.getTime()));
     private static final ValueReader TS_STR = new TimestampReader(
-            (w, i, v) -> w.writeText(i, UTC_TIMESTAMP_FORMAT.format(v.toInstant())));
+            (w, i, v) -> w.writeText(i, DateTimeFormatter.ISO_INSTANT.format(v.toInstant())));
 
     private static final ValueReader UUID_BINARY = new UuidReaderBinary();
     private static final ValueReader UUID_TEXT = new UuidReaderText();
@@ -598,6 +595,6 @@ public abstract class ValueReader {
 
     private static String date2str(Date date) {
         final LocalDate ld = date.toLocalDate();
-        return String.format("%d/%02d/%02d", ld.getYear(), ld.getMonthValue(), ld.getDayOfMonth());
+        return String.format("%d-%02d-%02d", ld.getYear(), ld.getMonthValue(), ld.getDayOfMonth());
     }
 }

--- a/src/main/java/tech/ydb/importer/target/ValueWriter.java
+++ b/src/main/java/tech/ydb/importer/target/ValueWriter.java
@@ -18,6 +18,10 @@ public interface ValueWriter {
 
     void writeBool(int idx, boolean v);
 
+    void writeUint8(int idx, int v);
+
+    void writeUint16(int idx, int v);
+
     void writeInt32(int idx, int v);
 
     void writeUint32(int idx, long v);

--- a/src/main/java/tech/ydb/importer/target/WriterPool.java
+++ b/src/main/java/tech/ydb/importer/target/WriterPool.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +23,6 @@ public class WriterPool implements AutoCloseable {
     private final BlockingQueue<UploadBatch> queue;
     private final int writerCount;
     private final ProgressCounter progress;
-    private final AtomicReference<Exception> firstError = new AtomicReference<>();
 
     public WriterPool(int writerCount, int queueCapacity, ProgressCounter progress) {
         this.writerCount = writerCount;
@@ -44,17 +42,8 @@ public class WriterPool implements AutoCloseable {
         }
     }
 
-    public void submit(UploadBatch batch) throws Exception {
-        checkError();
+    public void submit(UploadBatch batch) throws InterruptedException {
         queue.put(batch);
-        checkError();
-    }
-
-    private void checkError() throws Exception {
-        Exception err = firstError.get();
-        if (err != null) {
-            throw err;
-        }
     }
 
     public void shutdownAndWait() throws Exception {
@@ -71,11 +60,6 @@ public class WriterPool implements AutoCloseable {
                         + (SHUTDOWN_TIMEOUT_MS + FORCE_SHUTDOWN_TIMEOUT_MS) + " ms)");
             }
         }
-
-        Exception err = firstError.get();
-        if (err != null) {
-            throw err;
-        }
     }
 
     @Override
@@ -84,27 +68,26 @@ public class WriterPool implements AutoCloseable {
     }
 
     private void writerLoop() {
-        try {
-            while (true) {
-                UploadBatch batch = queue.take();
-                if (batch == UploadBatch.SHUTDOWN_SIGNAL) {
-                    return;
-                }
-                long started = System.nanoTime();
-                try {
-                    batch.getOp().upload(batch.getData(), batch.getRowCount(), batch.getOnFailure());
-                } finally {
-                    progress.countUploadBatch(System.nanoTime() - started);
-                }
+        while (true) {
+            UploadBatch batch;
+            try {
+                batch = queue.take();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
             }
-        } catch (InterruptedException e) {
-            firstError.compareAndSet(null, e);
-            queue.clear();
-            Thread.currentThread().interrupt();
-        } catch (Exception e) {
-            LOG.error("Writer thread {} failed", Thread.currentThread().getName(), e);
-            firstError.compareAndSet(null, e);
-            queue.clear();
+            if (batch == UploadBatch.SHUTDOWN_SIGNAL) {
+                return;
+            }
+            long started = System.nanoTime();
+            try {
+                batch.getOp().upload(batch.getData(), batch.getRowCount(), batch.getOnFailure());
+            } catch (Exception e) {
+                LOG.error("Upload failed for table {}", batch.label(), e);
+                batch.markFailed();
+            } finally {
+                progress.countUploadBatch(System.nanoTime() - started);
+            }
         }
     }
 }

--- a/src/main/java/tech/ydb/importer/target/YdbTypeMapper.java
+++ b/src/main/java/tech/ydb/importer/target/YdbTypeMapper.java
@@ -24,12 +24,24 @@ public final class YdbTypeMapper {
             case java.sql.Types.BIT:
                 return PrimitiveType.Bool;
             case java.sql.Types.TINYINT:
+                if (ci.isUnsigned()) {
+                    return PrimitiveType.Uint8;
+                }
                 return PrimitiveType.Int32;
             case java.sql.Types.SMALLINT:
+                if (ci.isUnsigned()) {
+                    return PrimitiveType.Uint16;
+                }
                 return PrimitiveType.Int32;
             case java.sql.Types.INTEGER:
+                if (ci.isUnsigned()) {
+                    return PrimitiveType.Uint32;
+                }
                 return PrimitiveType.Int32;
             case java.sql.Types.BIGINT:
+                if (ci.isUnsigned()) {
+                    return PrimitiveType.Uint64;
+                }
                 return PrimitiveType.Int64;
             case java.sql.Types.DECIMAL:
             case java.sql.Types.NUMERIC:
@@ -153,7 +165,6 @@ public final class YdbTypeMapper {
             case Uint8:
             case Uint16:
             case Uint32:
-            case Uint64:
                 return true;
             default:
                 return false;

--- a/src/main/java/tech/ydb/importer/target/YdbTypeMapper.java
+++ b/src/main/java/tech/ydb/importer/target/YdbTypeMapper.java
@@ -43,7 +43,7 @@ public final class YdbTypeMapper {
                     if (ci.getSqlPrecision() < 10) {
                         return PrimitiveType.Int32;
                     }
-                    if (ci.getSqlPrecision() < 20) {
+                    if (ci.getSqlPrecision() < 19) {
                         return PrimitiveType.Int64;
                     }
                     if (options.isAllowCustomDecimal()) {

--- a/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
@@ -298,8 +298,8 @@ public class ClickHouseYdbImporterTest {
             typeTest()
                     .withOptions(opts -> opts.setDateConv(DateConv.STR))
                     .column("Date", PrimitiveType.Text)
-                        .value("'1970-01-01'", "1970/01/01")
-                        .value("'2024-01-15'", "2024/01/15")
+                        .value("'1970-01-01'", "1970-01-01")
+                        .value("'2024-01-15'", "2024-01-15")
                     .execute();
         }
 

--- a/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/clickhouse/ClickHouseYdbImporterTest.java
@@ -97,39 +97,39 @@ public class ClickHouseYdbImporterTest {
         }
 
         @Test
-        public void uint8MapsToInt32() throws Exception {
+        public void uint8MapsToUint8() throws Exception {
             typeTest()
-                    .column("UInt8", PrimitiveType.Int32)
+                    .column("UInt8", PrimitiveType.Uint8)
                         .value("0", 0)
                         .value("255", 255)
                     .execute();
         }
 
         @Test
-        public void uint16MapsToInt32() throws Exception {
+        public void uint16MapsToUint16() throws Exception {
             typeTest()
-                    .column("UInt16", PrimitiveType.Int32)
+                    .column("UInt16", PrimitiveType.Uint16)
                         .value("0", 0)
                         .value("65535", 65535)
                     .execute();
         }
 
         @Test
-        public void uint32MapsToInt64() throws Exception {
+        public void uint32MapsToUint32() throws Exception {
             typeTest()
-                    .column("UInt32", PrimitiveType.Int64)
+                    .column("UInt32", PrimitiveType.Uint32)
                         .value("0", 0L)
                         .value("4294967295", 4294967295L)
                     .execute();
         }
 
         @Test
-        public void uint64MapsToDecimal() throws Exception {
+        public void uint64MapsToUint64() throws Exception {
             typeTest()
-                    .column("UInt64", DecimalType.of(35, 0))
-                        .value("0", new BigDecimal("0"))
+                    .column("UInt64", PrimitiveType.Uint64)
+                        .value("0", 0L)
                         .value("18446744073709551615",
-                               new BigDecimal("18446744073709551615"))
+                               Long.parseUnsignedLong("18446744073709551615"))
                     .execute();
         }
 

--- a/src/test/java/tech/ydb/importer/integration/sources/db2/Db2YdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/db2/Db2YdbImporterTest.java
@@ -254,6 +254,17 @@ public class Db2YdbImporterTest {
         }
 
         @Test
+        public void timestampNotShiftedByJvmZone() throws Exception {
+            typeTest()
+                    .withJvmTimeZone("GMT+6")
+                    .column("TIMESTAMP NOT NULL", PrimitiveType.Timestamp64)
+                        .value("'2024-01-15 10:30:45'",
+                                java.time.Instant.parse(
+                                        "2024-01-15T10:30:45Z"))
+                    .execute();
+        }
+
+        @Test
         public void timestampZeroMaps() throws Exception {
             typeTest()
                     .column("TIMESTAMP(0) NOT NULL",

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
@@ -111,6 +111,17 @@ public class HanaYdbImporterTest {
         }
 
         @Test
+        public void smalldecimalMapsToDouble() throws Exception {
+            typeTest()
+                    .column("SMALLDECIMAL NOT NULL", PrimitiveType.Double)
+                        .value("0", 0.0d)
+                        .value("1.5", 1.5d)
+                        .value("3.14", 3.14d)
+                        .value("-2.5", -2.5d)
+                    .execute();
+        }
+
+        @Test
         public void doublePrecision() throws Exception {
             typeTest()
                     .column("DOUBLE NOT NULL", PrimitiveType.Double)
@@ -166,17 +177,6 @@ public class HanaYdbImporterTest {
                         .value("1234567890123456789012345",
                                 new BigDecimal(
                                         "1234567890123456789012345"))
-                    .execute();
-        }
-
-        @Test
-        public void smallDecimalMaps() throws Exception {
-            // HANA SMALLDECIMAL reports as DECIMAL(16,0). Importer rule
-            // scale=0 + precision in 10-19 picks Int64.
-            typeTest()
-                    .column("SMALLDECIMAL NOT NULL", PrimitiveType.Int64)
-                        .value("12345", 12345L)
-                        .value("-67890", -67890L)
                     .execute();
         }
 

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
@@ -268,8 +268,8 @@ public class HanaYdbImporterTest {
                     .withOptions(
                             opts -> opts.setDateConv(DateConv.STR))
                     .column("DATE NOT NULL", PrimitiveType.Text)
-                        .value("'1970-01-01'", "1970/01/01")
-                        .value("'2024-01-15'", "2024/01/15")
+                        .value("'1970-01-01'", "1970-01-01")
+                        .value("'2024-01-15'", "2024-01-15")
                     .execute();
         }
 

--- a/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/hana/HanaYdbImporterTest.java
@@ -66,12 +66,12 @@ public class HanaYdbImporterTest {
         }
 
         @Test
-        public void tinyintMapsToInt32() throws Exception {
+        public void tinyintMapsToUint8() throws Exception {
             typeTest()
-                    .column("TINYINT NOT NULL", PrimitiveType.Int32)
+                    .column("TINYINT NOT NULL", PrimitiveType.Uint8)
                         .value("0", 0)
                         .value("255", 255)
-                    .column("TINYINT", PrimitiveType.Int32.makeOptional())
+                    .column("TINYINT", PrimitiveType.Uint8.makeOptional())
                         .value("42", 42)
                         .value("NULL", null)
                     .execute();

--- a/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/MariaDbColumnStoreYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mariadb/columnstore/MariaDbColumnStoreYdbImporterTest.java
@@ -125,6 +125,47 @@ public class MariaDbColumnStoreYdbImporterTest {
 
         @Test
         @Override
+        public void tinyintUnsignedMapsToUint8() throws Exception {
+            typeTest()
+                    .column("TINYINT UNSIGNED NOT NULL", PrimitiveType.Uint8)
+                        .value("0", 0)
+                        .value("200", 200)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        public void smallintUnsignedMapsToUint16() throws Exception {
+            typeTest()
+                    .column("SMALLINT UNSIGNED NOT NULL", PrimitiveType.Uint16)
+                        .value("0", 0)
+                        .value("50000", 50000)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        public void intUnsignedMapsToUint32() throws Exception {
+            typeTest()
+                    .column("INT UNSIGNED NOT NULL", PrimitiveType.Uint32)
+                        .value("0", 0L)
+                        .value("3000000000", 3000000000L)
+                    .execute();
+        }
+
+        @Test
+        @Override
+        public void bigintUnsignedMapsToUint64() throws Exception {
+            typeTest()
+                    .column("BIGINT UNSIGNED NOT NULL", PrimitiveType.Uint64)
+                        .value("0", 0L)
+                        .value("10000000000000000000",
+                                Long.parseUnsignedLong("10000000000000000000"))
+                    .execute();
+        }
+
+        @Test
+        @Override
         @Disabled("ColumnStore does not support JSON/ENUM")
         public void jsonAndEnumMapToText() throws Exception {
         }

--- a/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
@@ -1,6 +1,7 @@
 package tech.ydb.importer.integration.sources.mysql;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -299,6 +300,17 @@ public abstract class AbstractMySqlCompatibleTypeCases
                     .value("'00:00:00'", 0)
                     .value("'10:30:45'", 37845)
                     .value("'23:59:59'", 86399)
+                .execute();
+    }
+
+    @Test
+    public void datetime6PreservesMicroseconds() throws Exception {
+        typeTest()
+                .column("DATETIME(6) NOT NULL", PrimitiveType.Timestamp64)
+                    .value("'2024-01-15 10:30:45.123456'",
+                            Instant.parse("2024-01-15T10:30:45.123456Z"))
+                    .value("'2024-12-31 23:59:59.999999'",
+                            Instant.parse("2024-12-31T23:59:59.999999Z"))
                 .execute();
     }
 }

--- a/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
@@ -271,6 +271,16 @@ public abstract class AbstractMySqlCompatibleTypeCases
     }
 
     @Test
+    public void timestampNotShiftedByJvmZone() throws Exception {
+        typeTest()
+                .withJvmTimeZone("GMT+6")
+                .column("TIMESTAMP NOT NULL", PrimitiveType.Datetime64)
+                    .value("'2024-01-15 10:30:45'",
+                            LocalDateTime.of(2024, 1, 15, 10, 30, 45))
+                .execute();
+    }
+
+    @Test
     public void timestampAsTextUsesIso() throws Exception {
         typeTest()
                 .withOptions(opts -> opts.setTimestampConv(DateConv.STR))

--- a/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
@@ -313,4 +313,44 @@ public abstract class AbstractMySqlCompatibleTypeCases
                             Instant.parse("2024-12-31T23:59:59.999999Z"))
                 .execute();
     }
+
+    @Test
+    public void tinyintUnsignedMapsToUint8() throws Exception {
+        typeTest()
+                .column("TINYINT UNSIGNED NOT NULL", PrimitiveType.Uint8)
+                    .value("0", 0)
+                    .value("255", 255)
+                .execute();
+    }
+
+    @Test
+    public void smallintUnsignedMapsToUint16() throws Exception {
+        typeTest()
+                .column("SMALLINT UNSIGNED NOT NULL", PrimitiveType.Uint16)
+                    .value("0", 0)
+                    .value("65535", 65535)
+                .execute();
+    }
+
+    @Test
+    public void intUnsignedMapsToUint32() throws Exception {
+        typeTest()
+                .column("INT UNSIGNED NOT NULL", PrimitiveType.Uint32)
+                    .value("0", 0L)
+                    .value("2147483648", 2147483648L)
+                    .value("4294967295", 4294967295L)
+                .execute();
+    }
+
+    @Test
+    public void bigintUnsignedMapsToUint64() throws Exception {
+        typeTest()
+                .column("BIGINT UNSIGNED NOT NULL", PrimitiveType.Uint64)
+                    .value("0", 0L)
+                    .value("9223372036854775808",
+                            Long.parseUnsignedLong("9223372036854775808"))
+                    .value("18446744073709551615",
+                            Long.parseUnsignedLong("18446744073709551615"))
+                .execute();
+    }
 }

--- a/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/mysql/AbstractMySqlCompatibleTypeCases.java
@@ -255,8 +255,8 @@ public abstract class AbstractMySqlCompatibleTypeCases
         typeTest()
                 .withOptions(opts -> opts.setDateConv(DateConv.STR))
                 .column("DATE NOT NULL", PrimitiveType.Text)
-                    .value("'1970-01-01'", "1970/01/01")
-                    .value("'2024-01-15'", "2024/01/15")
+                    .value("'1970-01-01'", "1970-01-01")
+                    .value("'2024-01-15'", "2024-01-15")
                 .execute();
     }
 
@@ -267,6 +267,18 @@ public abstract class AbstractMySqlCompatibleTypeCases
                 .column("DATETIME NOT NULL", PrimitiveType.Datetime64)
                     .value("'2024-01-15 10:30:45'",
                             LocalDateTime.of(2024, 1, 15, 10, 30, 45))
+                .execute();
+    }
+
+    @Test
+    public void timestampAsTextUsesIso() throws Exception {
+        typeTest()
+                .withOptions(opts -> opts.setTimestampConv(DateConv.STR))
+                .column("TIMESTAMP(6) NOT NULL", PrimitiveType.Text)
+                    .value("'2024-01-15 10:30:45'",
+                            "2024-01-15T10:30:45Z")
+                    .value("'2024-01-15 10:30:45.123456'",
+                            "2024-01-15T10:30:45.123456Z")
                 .execute();
     }
 

--- a/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleLoader.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleLoader.java
@@ -18,7 +18,7 @@ public final class OracleLoader extends DialectLoader {
     protected String toDdl(LogicalType type) {
         switch (type) {
             case INT32:           return "NUMBER(10)";
-            case INT64:           return "NUMBER(19)";
+            case INT64:           return "NUMBER(18)";
             case DECIMAL_18_4:    return "NUMBER(18, 4)";
             case STRING:          return "VARCHAR2(255)";
             case BOOL:            return "BOOLEAN";

--- a/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleYdbImporterTest.java
@@ -216,6 +216,19 @@ public class OracleYdbImporterTest {
         }
 
         @Test
+        public void timestampNotShiftedByJvmZone() throws Exception {
+            typeTest()
+                    .withJvmTimeZone("GMT+6")
+                    .column("TIMESTAMP NOT NULL",
+                            PrimitiveType.Timestamp64)
+                        .value("TO_TIMESTAMP('2024-01-15 10:30:45',"
+                                + "'YYYY-MM-DD HH24:MI:SS')",
+                                java.time.Instant.parse(
+                                        "2024-01-15T10:30:45Z"))
+                    .execute();
+        }
+
+        @Test
         public void timestampZeroMaps() throws Exception {
             // TIMESTAMP(0) -> scale=0 -> Datetime64.
             typeTest()

--- a/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleYdbImporterTest.java
@@ -82,11 +82,11 @@ public class OracleYdbImporterTest {
         }
 
         @Test
-        public void numberLargeToInt64() throws Exception {
+        public void numberLargeToDecimal() throws Exception {
             typeTest()
-                    .column("NUMBER(19,0) NOT NULL", PrimitiveType.Int64)
+                    .column("NUMBER(19,0) NOT NULL", DecimalType.of(35, 0))
                         .value("1234567890123456789",
-                                1234567890123456789L)
+                                new BigDecimal("1234567890123456789"))
                     .execute();
         }
 
@@ -280,7 +280,7 @@ public class OracleYdbImporterTest {
                     .add(tableTest(s, "PK_OVER_UNIQUE")
                             .setupSql(
                                 "CREATE TABLE " + s + ".PK_OVER_UNIQUE ("
-                                + "ID   NUMBER(19,0) NOT NULL PRIMARY KEY,"
+                                + "ID   NUMBER(18,0) NOT NULL PRIMARY KEY,"
                                 + "CODE VARCHAR2(20) NOT NULL,"
                                 + "VAL  NUMBER(10,0),"
                                 + "CONSTRAINT UQ_ORA_CODE UNIQUE (CODE));"

--- a/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/oracle/OracleYdbImporterTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.oracle.OracleContainer;
 
 import tech.ydb.importer.config.SourceType;
+import tech.ydb.importer.config.TableOptions.DateConv;
 import tech.ydb.importer.integration.tabletest.AbstractYdbImporterTableTest;
 import tech.ydb.importer.integration.typetest.AbstractYdbImporterTypeTest;
 import tech.ydb.importer.integration.typetest.TypeTestBuilder;
@@ -224,6 +225,20 @@ public class OracleYdbImporterTest {
                                 + "'YYYY-MM-DD HH24:MI:SS')",
                                 LocalDateTime.of(2024, 1, 15,
                                         10, 30, 45))
+                    .execute();
+        }
+
+        @Test
+        public void timestampAsTextUsesIso() throws Exception {
+            typeTest()
+                    .withOptions(opts -> opts.setTimestampConv(DateConv.STR))
+                    .column("TIMESTAMP(9) NOT NULL", PrimitiveType.Text)
+                        .value("TO_TIMESTAMP('2024-01-15 10:30:45',"
+                                + "'YYYY-MM-DD HH24:MI:SS')",
+                                "2024-01-15T10:30:45Z")
+                        .value("TO_TIMESTAMP('2024-01-15 10:30:45.123456789',"
+                                + "'YYYY-MM-DD HH24:MI:SS.FF9')",
+                                "2024-01-15T10:30:45.123456789Z")
                     .execute();
         }
     }

--- a/src/test/java/tech/ydb/importer/integration/sources/postgres/AbstractPostgresCompatibleTypeCases.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/postgres/AbstractPostgresCompatibleTypeCases.java
@@ -229,8 +229,8 @@ public abstract class AbstractPostgresCompatibleTypeCases
         typeTest()
                 .withOptions(opts -> opts.setDateConv(DateConv.STR))
                 .column("DATE NOT NULL", PrimitiveType.Text)
-                    .value("DATE '1970-01-01'", "1970/01/01")
-                    .value("DATE '2024-01-15'", "2024/01/15")
+                    .value("DATE '1970-01-01'", "1970-01-01")
+                    .value("DATE '2024-01-15'", "2024-01-15")
                 .execute();
     }
 
@@ -271,6 +271,18 @@ public abstract class AbstractPostgresCompatibleTypeCases
                             Instant.parse("2024-01-15T10:30:45Z"))
                     .value("TIMESTAMPTZ '2024-06-20 15:00:00+03'",
                             Instant.parse("2024-06-20T12:00:00Z"))
+                .execute();
+    }
+
+    @Test
+    public void timestampAsTextUsesIso() throws Exception {
+        typeTest()
+                .withOptions(opts -> opts.setTimestampConv(DateConv.STR))
+                .column("TIMESTAMP NOT NULL", PrimitiveType.Text)
+                    .value("TIMESTAMP '2024-01-15 10:30:45'",
+                            "2024-01-15T10:30:45Z")
+                    .value("TIMESTAMP '2024-01-15 10:30:45.123456'",
+                            "2024-01-15T10:30:45.123456Z")
                 .execute();
     }
 

--- a/src/test/java/tech/ydb/importer/integration/sources/postgres/AbstractPostgresCompatibleTypeCases.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/postgres/AbstractPostgresCompatibleTypeCases.java
@@ -275,6 +275,16 @@ public abstract class AbstractPostgresCompatibleTypeCases
     }
 
     @Test
+    public void timestampNotShiftedByJvmZone() throws Exception {
+        typeTest()
+                .withJvmTimeZone("GMT+6")
+                .column("TIMESTAMP NOT NULL", PrimitiveType.Timestamp64)
+                    .value("TIMESTAMP '2024-01-15 10:30:45'",
+                            Instant.parse("2024-01-15T10:30:45Z"))
+                .execute();
+    }
+
+    @Test
     public void timestampAsTextUsesIso() throws Exception {
         typeTest()
                 .withOptions(opts -> opts.setTimestampConv(DateConv.STR))

--- a/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaYdbImporterTest.java
+++ b/src/test/java/tech/ydb/importer/integration/sources/vertica/VerticaYdbImporterTest.java
@@ -277,8 +277,8 @@ public class VerticaYdbImporterTest {
                     .withOptions(
                             opts -> opts.setDateConv(DateConv.STR))
                     .column("DATE NOT NULL", PrimitiveType.Text)
-                        .value("'1970-01-01'", "1970/01/01")
-                        .value("'2024-01-15'", "2024/01/15")
+                        .value("'1970-01-01'", "1970-01-01")
+                        .value("'2024-01-15'", "2024-01-15")
                     .execute();
         }
 

--- a/src/test/java/tech/ydb/importer/integration/typetest/TypeTestBuilder.java
+++ b/src/test/java/tech/ydb/importer/integration/typetest/TypeTestBuilder.java
@@ -7,6 +7,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
@@ -29,6 +30,7 @@ public final class TypeTestBuilder {
     private final List<TypeCase> completed = new ArrayList<>();
     private Consumer<TableOptions> optionsCustomizer = opts -> { };
     private String identifierQuote = "";
+    private String jvmTimeZone;
 
     private String currentSourceType;
     private Type currentExpectedYdbType;
@@ -47,6 +49,12 @@ public final class TypeTestBuilder {
     /** Customizes importer TableOptions for the test */
     public TypeTestBuilder withOptions(Consumer<TableOptions> customizer) {
         this.optionsCustomizer = customizer == null ? opts -> { } : customizer;
+        return this;
+    }
+
+    /** Sets the JVM default zone for the import */
+    public TypeTestBuilder withJvmTimeZone(String zoneId) {
+        this.jvmTimeZone = zoneId;
         return this;
     }
 
@@ -81,6 +89,11 @@ public final class TypeTestBuilder {
         String setupDdl = buildCreateTable(tableName);
         List<String> insertStatements = buildInserts(tableName);
 
+        TimeZone previousZone = null;
+        if (jvmTimeZone != null) {
+            previousZone = TimeZone.getDefault();
+            TimeZone.setDefault(TimeZone.getTimeZone(jvmTimeZone));
+        }
         try (YdbSchemaReader ydb = new YdbSchemaReader(
                 test.ydbContainer().getConnectionString())) {
             try {
@@ -90,6 +103,10 @@ public final class TypeTestBuilder {
             } finally {
                 cleanupSource(tableName);
                 ydb.dropTable(targetPath);
+            }
+        } finally {
+            if (previousZone != null) {
+                TimeZone.setDefault(previousZone);
             }
         }
     }


### PR DESCRIPTION
## Исправления ошибок

### Типы и форматы данных
* Изменен порог выбора типа для Decimal: значения с 19 цифрами не переходят в Int64 YDB.
* Даты и время в текстовом виде сохраняются в формате ISO-8601 без потери долей секунды.
* Исправлен подсчёт итоговой скорости загрузки в финальной статистике.

### Конвертация типов в YDB
* MySQL/MariaDB: беззнаковые целые типы переносятся без переполнения: `TINYINT`/`SMALLINT UNSIGNED` -> Uint8/Uint16 (вместо Int32), `INT UNSIGNED` -> Uint32 (вместо Int32), `BIGINT UNSIGNED` -> Uint64 (вместо Int64).
* MySQL: `DATETIME(N)`/`TIMESTAMP(N)` с долями секунды переносятся в Timestamp64 без потери микросекунд (раньше конвертировались в Datetime64).
* ClickHouse: `UInt8`/`UInt16`/`UInt32`/`UInt64` переносятся в Uint8/Uint16/Uint32/Uint64 (вместо Int32/Int64 или Decimal).
* HANA: `SMALLDECIMAL` переносится в Double без потери дробной части (раньше Int64). Также беззнаковый `TINYINT` -> Uint8.

### Партиционирование
* Значение параметра партиционирования "none" переименовано в "ydb-managed".
* Убрана лишняя перегруппировка строк по буферам, когда порядок чтения совпадает с разбиением целевой таблицы.

### Конвейер
* Ошибка записи одной таблицы больше не прерывает перенос: таблица пропускается, остальные загружаются.

### Источники данных
* DB2: для не LUW используется универсальный режим чтения метаданных, убрана лишняя обрезка пробелов в именах из системного каталога.
* Vertica: пустой ключ партиции вызывает явную ошибку.
* ClickHouse: выбор autocommit вынесен в свойство источника, добавлено пояснение про параметр fetch-size в документации, логирование чтения диапазонов изменено с info на debug.

### Тесты
* Добавлены тесты переноса времени при часовом поясе, отличном от UTC (JVM GMT+6).